### PR TITLE
feat: academic domain (Inverted Interview, second manifestation)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -33,6 +33,7 @@ import { registerSearchRoutes } from './routes/search';
 import { registerDidRoutes } from './routes/did';
 import sbtRoutes from './routes/sbt';
 import marketplaceRoutes from './routes/marketplace';
+import academicRoutes from './routes/academic';
 import { registerIdentityRoutes } from './routes/identity';
 import { demoRoutes } from './routes/demo';
 import { registerGraphQLRoute } from './routes/graphql';
@@ -554,6 +555,7 @@ export function buildServer(options: ApiServerOptions = {}) {
     scope.register(registerArtifactRoutes);
     scope.register(sbtRoutes);
     scope.register(marketplaceRoutes);
+    scope.register(academicRoutes);
     scope.register(registerIntegrationRoutes);
     scope.register(registerSearchRoutes, {
       prefix: '/search',

--- a/apps/api/src/routes/academic.ts
+++ b/apps/api/src/routes/academic.ts
@@ -1,0 +1,108 @@
+/**
+ * Academic Domain API Routes
+ *
+ * The academic counterpart to the Hunter Protocol routes. Stateless and
+ * computation-only (no persistence), these endpoints surface the academic
+ * core engine — research-impact bibliometrics and scholar ⇄ position
+ * compatibility scoring — plus the academic taxonomy and CV renderer.
+ *
+ * Endpoints:
+ *   - GET  /academic/taxonomy           Enumerations + role families
+ *   - POST /academic/research-impact     Works[] → author-level metrics
+ *   - POST /academic/analyze-position    Position + profile → fit analysis
+ *   - POST /academic/cv                  Profile → ordered CV sections
+ */
+
+import type { FastifyPluginCallback } from 'fastify';
+import {
+  AcademicPositionSchema,
+  AcademicProfileSchema,
+  CreditRoleSchema,
+  InstitutionTypeSchema,
+  PositionTypeSchema,
+  PublicationStatusSchema,
+  ScholarlyWorkSchema,
+  ScholarlyWorkTypeSchema,
+  z,
+} from '@in-midst-my-life/schema';
+import { computeResearchImpact, createAcademicAnalyzer } from '@in-midst-my-life/core';
+import { ACADEMIC_ROLE_FAMILIES, buildAcademicCv } from '@in-midst-my-life/content-model';
+
+const ResearchImpactRequestSchema = z.object({
+  works: ScholarlyWorkSchema.array(),
+});
+
+const AnalyzePositionRequestSchema = z.object({
+  position: AcademicPositionSchema,
+  profile: AcademicProfileSchema,
+  preferredLocations: z.string().array().optional(),
+});
+
+const CvRequestSchema = z.object({
+  profile: AcademicProfileSchema,
+});
+
+const academicRoutes: FastifyPluginCallback = (server, _opts, done) => {
+  const analyzer = createAcademicAnalyzer();
+
+  /**
+   * GET /academic/taxonomy
+   * Returns the academic enumerations and role-family personas. Public.
+   */
+  server.get('/academic/taxonomy', async (_request, reply) => {
+    return reply.send({
+      creditRoles: CreditRoleSchema.options,
+      publicationTypes: ScholarlyWorkTypeSchema.options,
+      publicationStatuses: PublicationStatusSchema.options,
+      positionTypes: PositionTypeSchema.options,
+      institutionTypes: InstitutionTypeSchema.options,
+      roleFamilies: ACADEMIC_ROLE_FAMILIES,
+    });
+  });
+
+  /**
+   * POST /academic/research-impact
+   * Compute author-level bibliometrics (h-index, i10-index, ...) from works.
+   */
+  server.post('/academic/research-impact', async (request, reply) => {
+    const parsed = ResearchImpactRequestSchema.safeParse(request.body);
+    if (!parsed.success) {
+      return reply.status(400).send({ error: 'Invalid request', details: parsed.error.issues });
+    }
+    const metrics = computeResearchImpact(parsed.data.works);
+    return reply.send(metrics);
+  });
+
+  /**
+   * POST /academic/analyze-position
+   * Score a scholar's ledger against an academic position.
+   */
+  server.post('/academic/analyze-position', async (request, reply) => {
+    const parsed = AnalyzePositionRequestSchema.safeParse(request.body);
+    if (!parsed.success) {
+      return reply.status(400).send({ error: 'Invalid request', details: parsed.error.issues });
+    }
+    const { position, profile, preferredLocations } = parsed.data;
+    const analysis = analyzer.analyze(
+      preferredLocations ? { position, profile, preferredLocations } : { position, profile },
+    );
+    return reply.send(analysis);
+  });
+
+  /**
+   * POST /academic/cv
+   * Render an academic profile into conventionally-ordered CV sections.
+   */
+  server.post('/academic/cv', async (request, reply) => {
+    const parsed = CvRequestSchema.safeParse(request.body);
+    if (!parsed.success) {
+      return reply.status(400).send({ error: 'Invalid request', details: parsed.error.issues });
+    }
+    const cv = buildAcademicCv(parsed.data.profile);
+    return reply.send(cv);
+  });
+
+  done();
+};
+
+export default academicRoutes;

--- a/apps/api/test/academic.test.ts
+++ b/apps/api/test/academic.test.ts
@@ -1,0 +1,159 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { buildTestApp } from './app-builder';
+
+const uuid = (n: number): string => `00000000-0000-0000-0000-${n.toString().padStart(12, '0')}`;
+
+describe('academic routes', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    app = await buildTestApp();
+  });
+
+  it('exposes the academic taxonomy', async () => {
+    const res = await app.inject({ method: 'GET', url: '/academic/taxonomy' });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.creditRoles).toHaveLength(14);
+    expect(body.institutionTypes).toContain('r1-research');
+    const familyIds = body.roleFamilies.map((f: any) => f.id);
+    expect(familyIds).toContain('research-scholar');
+  });
+
+  it('computes research impact metrics from works', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/academic/research-impact',
+      payload: {
+        works: [
+          { id: uuid(1), title: 'P1', type: 'journal-article', year: 2020, citations: 12 },
+          { id: uuid(2), title: 'P2', type: 'journal-article', year: 2021, citations: 11 },
+          { id: uuid(3), title: 'P3', type: 'conference-paper', year: 2022, citations: 3 },
+        ],
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.totalPublications).toBe(3);
+    expect(body.hIndex).toBe(3);
+    expect(body.i10Index).toBe(2);
+  });
+
+  it('rejects malformed research-impact requests', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/academic/research-impact',
+      payload: { works: [{ title: 'missing id and type' }] },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('analyzes a scholar against an academic position', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/academic/analyze-position',
+      payload: {
+        position: {
+          id: uuid(10),
+          title: 'Assistant Professor',
+          institution: 'State R1',
+          institutionType: 'r1-research',
+          positionType: 'tenure-track',
+          researchExpectation: 80,
+          teachingExpectation: 15,
+          serviceExpectation: 5,
+          fundingExpected: true,
+          subfields: ['machine learning'],
+        },
+        profile: {
+          researchAreas: ['machine learning'],
+          works: [
+            {
+              id: uuid(1),
+              title: 'P1',
+              type: 'journal-article',
+              year: 2020,
+              citations: 30,
+              authorPosition: 'first',
+            },
+            {
+              id: uuid(2),
+              title: 'P2',
+              type: 'journal-article',
+              year: 2021,
+              citations: 25,
+              authorPosition: 'first',
+            },
+            { id: uuid(3), title: 'P3', type: 'journal-article', year: 2022, citations: 20 },
+          ],
+          fundings: [
+            {
+              id: uuid(100),
+              title: 'NSF Grant',
+              agency: 'NSF',
+              role: 'principal-investigator',
+              amount: 600000,
+              status: 'active',
+            },
+          ],
+        },
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.position_id).toBe(uuid(10));
+    expect(body.overall_score).toBeGreaterThanOrEqual(0);
+    expect(body.overall_score).toBeLessThanOrEqual(100);
+    expect(['strong_apply', 'competitive', 'reach', 'developmental', 'skip']).toContain(
+      body.recommendation,
+    );
+    expect(body.metrics.totalPublications).toBe(3);
+  });
+
+  it('renders an academic CV in conventional section order', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/academic/cv',
+      payload: {
+        profile: {
+          researchAreas: ['nlp'],
+          works: [
+            {
+              id: uuid(1),
+              title: 'Published Paper',
+              type: 'journal-article',
+              year: 2023,
+              citations: 5,
+              status: 'published',
+            },
+            {
+              id: uuid(2),
+              title: 'Submitted Paper',
+              type: 'journal-article',
+              year: 2024,
+              status: 'under-review',
+            },
+          ],
+          teaching: [
+            { id: uuid(3), title: 'Intro to NLP', institution: 'State U', level: 'graduate' },
+          ],
+        },
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    const sectionIds = body.sections.map((s: any) => s.id);
+    expect(sectionIds).toContain('research-areas');
+    expect(sectionIds).toContain('publications-published');
+    expect(sectionIds).toContain('publications-under-review');
+    expect(sectionIds).toContain('teaching');
+    // Research areas precede publications precede teaching.
+    expect(sectionIds.indexOf('research-areas')).toBeLessThan(
+      sectionIds.indexOf('publications-published'),
+    );
+    expect(sectionIds.indexOf('publications-published')).toBeLessThan(
+      sectionIds.indexOf('teaching'),
+    );
+  });
+});

--- a/docs/features/academic-domain/ACADEMIC-DOMAIN.md
+++ b/docs/features/academic-domain/ACADEMIC-DOMAIN.md
@@ -1,0 +1,149 @@
+# The Academic Domain
+
+> Product manifestation #2. The Inverted Interview engine, first manifested for
+> the **market** (the Hunter Protocol — matching a candidate to a *job*), now
+> manifests for the **academy** — matching a scholar to an *academic position*
+> on the research–teaching–service triangle.
+
+This document does three things the seeding directive asked for: it **reviews
+the internal precedent process** the academic domain mirrors, it **studies the
+external instances** (real-world standards) the schema is anchored to, and it
+**surfaces every surface** — internal (the code seams) and external (the
+ecosystems we round-trip with) — through which the domain manifests.
+
+---
+
+## 1. Internal precedent: the market domain
+
+The academic domain is a deliberate mirror of the market-facing **Hunter
+Protocol**. Each layer has a one-to-one counterpart, so the precedent process is
+re-used rather than reinvented:
+
+| Concern | Market (precedent) | Academic (this domain) |
+|---|---|---|
+| Opportunity entity | `JobListing` | `AcademicPosition` |
+| Candidate ledger | `Profile` (skills/experience) | `AcademicProfile` (works/grants/teaching/service) |
+| "Benchmark" engine | `MarketRateAnalyzer` (salary percentiles) | `computeResearchImpact` (h-index / i10-index) |
+| Fit engine | `DefaultCompatibilityAnalyzer` (skill/culture/comp/growth/location) | `AcademicCompatibilityAnalyzer` (research/teaching/funding/service/location) |
+| Personas | role-families (job-title → mask blend) | `ACADEMIC_ROLE_FAMILIES` (position → mask blend) |
+| Recommendation bands | `apply_now … skip` | `strong_apply … skip` |
+
+The mirror is intentional: the same "review precedent → replicate the
+layer pattern" process used to grow the market domain (`schema → core →
+content-model → api → tests`) is what grew this one.
+
+### Why personas are role-families, not new masks
+
+The system has exactly 16 functional masks bound together by stage-affinity and
+epoch-modifier matrices (`packages/content-model/src/taxonomy.ts`). Minting new
+"Scholar" masks would destabilise those matrices. Instead — exactly as the
+market domain maps *job titles* to mask blends — academic personas are expressed
+as **role-families** over the existing masks (e.g. `research-scholar` =
+analyst+synthesist+interpreter+narrator). This is the non-invasive extension
+point the precedent already established.
+
+---
+
+## 2. External instances (studied & cited)
+
+The schema is not invented; it is anchored to the standards the academy actually
+uses, so an academic ledger can round-trip with the wider scholarly ecosystem.
+
+- **ORCID record model** — the canonical machine-readable scholarly identity.
+  Our `ScholarlyWork`, `Funding`, `ServiceRecord` and `AcademicPosition`
+  entities mirror ORCID's *works*, *fundings*, *services* and *affiliations*
+  activity sections (each carrying titles, organisations, dates and external
+  identifiers).
+  <https://info.orcid.org/documentation/integration-guide/orcid-record/>
+- **CRediT — Contributor Roles Taxonomy (ANSI/NISO Z39.104-2022)** — the 14
+  standard contributor roles. Encoded verbatim as `CreditRoleSchema` and carried
+  on each `ScholarlyWork.contributorRoles`.
+  <https://credit.niso.org/>
+- **Author-level impact metrics (h-index, i10-index)** — `computeResearchImpact`
+  implements the textbook definitions: h-index is the largest *h* such that *h*
+  works are each cited ≥ *h* times; i10-index is the count of works with ≥ 10
+  citations (a Google Scholar metric).
+  <https://en.wikipedia.org/wiki/H-index>
+- **Academic-CV conventions** — the section ordering produced by `buildAcademicCv`
+  (research areas → publications by status/type → grants → teaching → service)
+  follows the guidance published by university career-services offices, e.g.
+  [UPenn Career Services](https://careerservices.upenn.edu/application-materials-for-the-faculty-job-search/cvs-for-faculty-job-applications/)
+  and [MIT CAPD](https://capd.mit.edu/resources/cvs/).
+- **The faculty job market** — the institution-type weighting (R1 research-heavy
+  vs. primarily-undergraduate teaching-heavy, 2-2 vs. 4-4 loads) reflects how
+  tenure criteria actually differ across institution types, per academic
+  job-market guides such as [Lehigh Postdoctoral Affairs](https://postdoc.lehigh.edu/career-development/academic-job-search-practical-timeline-guide).
+
+---
+
+## 3. Surfaces (internal + external)
+
+> "All surfaces require surfacing." Every point at which the academic domain is
+> exposed.
+
+### Internal surfaces (code seams)
+
+| Layer | File | Surface |
+|---|---|---|
+| Schema | `packages/schema/src/academic.ts` | `ScholarlyWork`, `Funding`, `TeachingRecord`, `ServiceRecord`, `AcademicPosition`, `AcademicProfile`, `ResearchImpactMetrics`, `AcademicCompatibilityAnalysis`, `CreditRole`, `ScholarlyWorkType` |
+| Core | `packages/core/src/academic/` | `computeHIndex`, `computeI10Index`, `computeResearchImpact`, `AcademicCompatibilityAnalyzer`, `createAcademicAnalyzer` |
+| Content-model | `packages/content-model/src/academic.ts` | `ACADEMIC_ROLE_FAMILIES`, `matchAcademicRoleFamily`, `buildAcademicCv` |
+| API | `apps/api/src/routes/academic.ts` | the HTTP surface (below) |
+
+### API surface
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/academic/taxonomy` | CRediT roles, work types, position/institution types, role-family personas |
+| `POST` | `/academic/research-impact` | `{ works[] }` → author-level bibliometrics |
+| `POST` | `/academic/analyze-position` | `{ position, profile, preferredLocations? }` → compatibility analysis |
+| `POST` | `/academic/cv` | `{ profile }` → ordered academic-CV sections |
+
+### External surfaces (ecosystem round-trip)
+
+The domain is shaped so the ledger can surface *outward* into the scholarly
+graph: ORCID (works/fundings/services), CRediT (contributor attribution on
+publications), and Scholar-style impact metrics. These are the external faces of
+the same identity the market domain exposes through LinkedIn/JSON-LD.
+
+---
+
+## 4. The scoring model
+
+`AcademicCompatibilityAnalyzer` is **position-driven**: the research / teaching /
+service expectation triangle declared on the `AcademicPosition` (which encodes
+institution type) is normalised into the bulk of the score, with funding and
+location taking fixed slices. The consequence is that the *same scholar* scores
+very differently across postings:
+
+- A research-heavy scholar (high h-index, no teaching record) scores **strongly**
+  against an R1 tenure-track line (`researchExpectation: 80`) …
+- … and **weakly** against a teaching-focused PUI line (`teachingExpectation:
+  70`), which also flips the suggested persona from `research-scholar` to
+  `teaching-scholar`.
+
+Funding is asymmetric by design: when a line *expects* external grant capture,
+its absence is a flagged gap; when it does not, funding can only help.
+
+---
+
+## 5. Tests
+
+| Suite | File |
+|---|---|
+| Schema validation | `packages/schema/test/academic.test.ts` |
+| Bibliometrics | `packages/core/test/academic-research-impact.test.ts` |
+| Compatibility scoring | `packages/core/test/academic-analyzer.test.ts` |
+| API routes | `apps/api/test/academic.test.ts` |
+
+---
+
+## Sources
+
+- ORCID Record Schema — <https://info.orcid.org/documentation/integration-guide/orcid-record/>
+- CRediT — Contributor Roles Taxonomy (ANSI/NISO Z39.104-2022) — <https://credit.niso.org/>
+- h-index — <https://en.wikipedia.org/wiki/H-index>
+- i10-index — <https://guides.library.cornell.edu/impact/author-impact-10>
+- CVs for Faculty Job Applications, UPenn Career Services — <https://careerservices.upenn.edu/application-materials-for-the-faculty-job-search/cvs-for-faculty-job-applications/>
+- Curricula Vitae, MIT CAPD — <https://capd.mit.edu/resources/cvs/>
+- Academic Job Search: A Practical Timeline & Guide, Lehigh — <https://postdoc.lehigh.edu/career-development/academic-job-search-practical-timeline-guide>

--- a/packages/content-model/src/academic.ts
+++ b/packages/content-model/src/academic.ts
@@ -1,0 +1,290 @@
+/**
+ * Academic Domain — Content Model
+ *
+ * Two non-invasive extensions for the academic domain:
+ *
+ *   1. ACADEMIC_ROLE_FAMILIES — academic "personas" expressed as blends of the
+ *      existing 16 functional masks (the same mechanism role-families.ts uses
+ *      for industry job titles). This avoids minting new mask types, which
+ *      would destabilise the mask/stage/epoch affinity matrices.
+ *
+ *   2. buildAcademicCv — renders an AcademicProfile into the canonical
+ *      academic-CV section order (research areas → publications grouped by
+ *      status/type → grants → teaching → service), following the conventions
+ *      published by university career-services offices.
+ */
+
+import type {
+  AcademicProfile,
+  Funding,
+  PublicationStatus,
+  ScholarlyWork,
+  ServiceRecord,
+  TeachingRecord,
+} from '@in-midst-my-life/schema';
+import type { RoleFamily } from './role-families';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ROLE FAMILIES (academic personas as mask blends)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const ACADEMIC_ROLE_FAMILIES: RoleFamily[] = [
+  {
+    id: 'research-scholar',
+    name: 'Research Scholar',
+    aliases: [
+      'research professor',
+      'research scientist',
+      'research fellow',
+      'postdoctoral researcher',
+      'postdoctoral fellow',
+      'principal investigator',
+      'tenure-track professor',
+      'assistant professor',
+      'associate professor',
+    ],
+    maskBlend: [
+      { maskId: 'analyst', weight: 0.35 },
+      { maskId: 'synthesist', weight: 0.25 },
+      { maskId: 'interpreter', weight: 0.2 },
+      { maskId: 'narrator', weight: 0.2 },
+    ],
+    emphasisTags: ['research', 'analysis', 'publication', 'methodology'],
+    deEmphasisTags: ['operations', 'delivery'],
+  },
+  {
+    id: 'teaching-scholar',
+    name: 'Teaching Scholar',
+    aliases: [
+      'teaching professor',
+      'lecturer',
+      'senior lecturer',
+      'instructor',
+      'teaching faculty',
+      'professor of practice',
+      'clinical professor',
+    ],
+    maskBlend: [
+      { maskId: 'narrator', weight: 0.3 },
+      { maskId: 'mediator', weight: 0.3 },
+      { maskId: 'interpreter', weight: 0.2 },
+      { maskId: 'steward', weight: 0.2 },
+    ],
+    emphasisTags: ['pedagogy', 'communication', 'mentorship', 'curriculum'],
+    deEmphasisTags: ['speculation'],
+  },
+  {
+    id: 'scholar-educator',
+    name: 'Scholar-Educator',
+    aliases: [
+      'professor',
+      'faculty',
+      'department chair',
+      'liberal arts professor',
+      'comprehensive university professor',
+    ],
+    maskBlend: [
+      { maskId: 'synthesist', weight: 0.25 },
+      { maskId: 'narrator', weight: 0.25 },
+      { maskId: 'mediator', weight: 0.25 },
+      { maskId: 'analyst', weight: 0.25 },
+    ],
+    emphasisTags: ['research', 'pedagogy', 'synthesis', 'service'],
+    deEmphasisTags: [],
+  },
+  {
+    id: 'principal-investigator',
+    name: 'Principal Investigator',
+    aliases: [
+      'lab director',
+      'center director',
+      'research group leader',
+      'grant principal investigator',
+      'program director',
+    ],
+    maskBlend: [
+      { maskId: 'strategist', weight: 0.3 },
+      { maskId: 'steward', weight: 0.25 },
+      { maskId: 'architect', weight: 0.25 },
+      { maskId: 'narrator', weight: 0.2 },
+    ],
+    emphasisTags: ['funding', 'leadership', 'vision', 'supervision'],
+    deEmphasisTags: ['tactical'],
+  },
+];
+
+/**
+ * Match an academic position title to a role family. Mirrors matchRoleFamily
+ * but over the academic catalogue. Returns undefined when nothing matches so
+ * callers can fall back to keyword scoring.
+ */
+export function matchAcademicRoleFamily(positionTitle: string): RoleFamily | undefined {
+  const normalized = positionTitle.trim().toLowerCase();
+  if (normalized.length < 2) return undefined;
+
+  for (const family of ACADEMIC_ROLE_FAMILIES) {
+    for (const alias of family.aliases) {
+      if (normalized.includes(alias) || alias.includes(normalized)) {
+        return family;
+      }
+    }
+  }
+  return undefined;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ACADEMIC CV RENDERING
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface AcademicCvEntry {
+  id: string;
+  /** Primary line — e.g. a publication title or course title. */
+  primary: string;
+  /** Secondary detail — venue, institution, agency. */
+  secondary?: string;
+  /** Trailing metadata — year, citations, amount. */
+  meta?: string;
+}
+
+export interface AcademicCvSection {
+  id: string;
+  title: string;
+  entries: AcademicCvEntry[];
+}
+
+export interface AcademicCv {
+  sections: AcademicCvSection[];
+}
+
+/** Human-readable ordering for the publication-status subsections. */
+const PUBLICATION_STATUS_ORDER: PublicationStatus[] = [
+  'published',
+  'in-press',
+  'under-review',
+  'in-preparation',
+];
+
+const STATUS_LABELS: Record<PublicationStatus, string> = {
+  published: 'Published',
+  'in-press': 'In Press',
+  'under-review': 'Under Review',
+  'in-preparation': 'In Preparation',
+};
+
+function workEntry(work: ScholarlyWork): AcademicCvEntry {
+  const metaParts = [String(work.year)];
+  if (work.status === 'published' || work.status === 'in-press') {
+    metaParts.push(`${work.citations} citations`);
+  } else {
+    metaParts.push(STATUS_LABELS[work.status]);
+  }
+  return {
+    id: work.id,
+    primary: work.title,
+    secondary: work.venue,
+    meta: metaParts.join(' · '),
+  };
+}
+
+function publicationSections(works: ScholarlyWork[]): AcademicCvSection[] {
+  const sections: AcademicCvSection[] = [];
+  for (const status of PUBLICATION_STATUS_ORDER) {
+    const inStatus = works.filter((w) => w.status === status).sort((a, b) => b.year - a.year);
+    if (inStatus.length === 0) continue;
+    sections.push({
+      id: `publications-${status}`,
+      title: `Publications — ${STATUS_LABELS[status]}`,
+      entries: inStatus.map(workEntry),
+    });
+  }
+  return sections;
+}
+
+function fundingEntry(grant: Funding): AcademicCvEntry {
+  const metaParts: string[] = [];
+  if (typeof grant.amount === 'number') {
+    metaParts.push(`${grant.currency} ${grant.amount.toLocaleString()}`);
+  }
+  metaParts.push(grant.role);
+  metaParts.push(grant.status);
+  return {
+    id: grant.id,
+    primary: grant.title,
+    secondary: grant.grantNumber ? `${grant.agency} (${grant.grantNumber})` : grant.agency,
+    meta: metaParts.join(' · '),
+  };
+}
+
+function teachingEntry(record: TeachingRecord): AcademicCvEntry {
+  const metaParts: string[] = [record.level, record.format];
+  if (typeof record.enrollment === 'number') metaParts.push(`${record.enrollment} enrolled`);
+  if (typeof record.evaluationScore === 'number') {
+    metaParts.push(`eval ${record.evaluationScore.toFixed(1)}/5`);
+  }
+  return {
+    id: record.id,
+    primary: record.courseCode ? `${record.courseCode}: ${record.title}` : record.title,
+    secondary: record.term ? `${record.institution} · ${record.term}` : record.institution,
+    meta: metaParts.join(' · '),
+  };
+}
+
+function serviceEntry(record: ServiceRecord): AcademicCvEntry {
+  const metaParts: string[] = [record.category];
+  if (typeof record.peerReviewCount === 'number') {
+    metaParts.push(`${record.peerReviewCount} reviews`);
+  }
+  return {
+    id: record.id,
+    primary: record.role,
+    secondary: record.organization,
+    meta: metaParts.join(' · '),
+  };
+}
+
+/**
+ * Render an AcademicProfile into ordered CV sections following the conventional
+ * academic-CV ordering. Empty sections are omitted.
+ */
+export function buildAcademicCv(profile: AcademicProfile): AcademicCv {
+  const sections: AcademicCvSection[] = [];
+
+  if (profile.researchAreas.length > 0) {
+    sections.push({
+      id: 'research-areas',
+      title: 'Research Areas',
+      entries: profile.researchAreas.map((area, i) => ({
+        id: `research-area-${i}`,
+        primary: area,
+      })),
+    });
+  }
+
+  sections.push(...publicationSections(profile.works));
+
+  if (profile.fundings.length > 0) {
+    sections.push({
+      id: 'grants-funding',
+      title: 'Grants & Funding',
+      entries: profile.fundings.map(fundingEntry),
+    });
+  }
+
+  if (profile.teaching.length > 0) {
+    sections.push({
+      id: 'teaching',
+      title: 'Teaching',
+      entries: profile.teaching.map(teachingEntry),
+    });
+  }
+
+  if (profile.service.length > 0) {
+    sections.push({
+      id: 'service',
+      title: 'Service',
+      entries: profile.service.map(serviceEntry),
+    });
+  }
+
+  return { sections };
+}

--- a/packages/content-model/src/index.ts
+++ b/packages/content-model/src/index.ts
@@ -98,6 +98,9 @@ export * from './compatibility';
 // Role-family taxonomy
 export * from './role-families';
 
+// Academic domain (role families + CV rendering)
+export * from './academic';
+
 // Tone analysis
 export * from './tone';
 

--- a/packages/core/src/academic/academic-analyzer.ts
+++ b/packages/core/src/academic/academic-analyzer.ts
@@ -1,0 +1,241 @@
+/**
+ * Academic Compatibility Analyzer
+ *
+ * The academic mirror of the Hunter Protocol's DefaultCompatibilityAnalyzer.
+ * Instead of scoring a candidate against a job on skill/culture/compensation,
+ * it scores a scholar against an academic position on the canonical
+ * research–teaching–service triangle, plus funding and location.
+ *
+ * Crucially, the weighting is *position-driven*: an R1 tenure-track line that
+ * declares research_expectation=80 will weigh publications heavily, while a
+ * primarily-undergraduate institution that declares teaching_expectation=70
+ * will reward a strong teaching record instead — the same posting can yield
+ * very different overall scores for the same scholar.
+ */
+
+import type {
+  AcademicCompatibilityAnalysis,
+  AcademicPosition,
+  AcademicProfile,
+  AcademicRecommendation,
+  Funding,
+  ResearchImpactMetrics,
+} from '@in-midst-my-life/schema';
+import { computeResearchImpact } from './research-impact';
+
+export interface AcademicAnalysisInput {
+  position: AcademicPosition;
+  profile: AcademicProfile;
+  /** Optional location preferences for the location_fit dimension. */
+  preferredLocations?: string[];
+}
+
+const clamp = (n: number): number => Math.round(Math.min(100, Math.max(0, n)));
+
+const normalize = (s: string): string => s.trim().toLowerCase();
+
+/** Map a 0–100 overall score to a recommendation band. */
+function recommend(score: number): AcademicRecommendation {
+  if (score >= 80) return 'strong_apply';
+  if (score >= 65) return 'competitive';
+  if (score >= 50) return 'reach';
+  if (score >= 35) return 'developmental';
+  return 'skip';
+}
+
+function externalPiGrants(fundings: Funding[]): Funding[] {
+  return fundings.filter(
+    (f) =>
+      f.external &&
+      (f.role === 'principal-investigator' || f.role === 'co-principal-investigator') &&
+      (f.status === 'awarded' || f.status === 'active' || f.status === 'completed'),
+  );
+}
+
+function subfieldOverlapScore(position: AcademicPosition, profile: AcademicProfile): number {
+  if (position.subfields.length === 0) return 60; // neutral when the line is open
+  const areas = new Set(profile.researchAreas.map(normalize));
+  const matched = position.subfields.filter((s) => areas.has(normalize(s))).length;
+  return clamp((matched / position.subfields.length) * 100);
+}
+
+function researchFit(
+  position: AcademicPosition,
+  profile: AcademicProfile,
+  metrics: ResearchImpactMetrics,
+): number {
+  const hComponent = Math.min(100, metrics.hIndex * 6);
+  const pubComponent = Math.min(100, metrics.totalPublications * 8);
+  const subfieldComponent = subfieldOverlapScore(position, profile);
+  return clamp(0.4 * hComponent + 0.25 * pubComponent + 0.35 * subfieldComponent);
+}
+
+function teachingFit(profile: AcademicProfile): number {
+  const records = profile.teaching;
+  const countComponent = Math.min(100, records.length * 15);
+
+  const scored = records.filter((r) => typeof r.evaluationScore === 'number');
+  const evalComponent =
+    scored.length === 0
+      ? 60 // neutral when no evaluations are on record
+      : clamp(
+          (scored.reduce((sum, r) => sum + (r.evaluationScore ?? 0), 0) / scored.length / 5) * 100,
+        );
+
+  const distinctLevels = new Set(records.map((r) => r.level)).size;
+  const breadthComponent = Math.min(100, (distinctLevels / 4) * 100);
+
+  return clamp(0.4 * countComponent + 0.4 * evalComponent + 0.2 * breadthComponent);
+}
+
+function fundingFit(position: AcademicPosition, profile: AcademicProfile): number {
+  const piGrants = externalPiGrants(profile.fundings);
+  const totalAwarded = piGrants.reduce((sum, g) => sum + (g.amount ?? 0), 0);
+
+  if (position.fundingExpected) {
+    if (piGrants.length === 0) return 20; // a grant-expecting line with no external PI funding
+    const piComponent = Math.min(100, piGrants.length * 40);
+    const amountComponent = Math.min(100, (totalAwarded / 500_000) * 100);
+    return clamp(0.6 * piComponent + 0.4 * amountComponent);
+  }
+
+  // Funding not expected: presence is a bonus, absence is not penalised.
+  return clamp(70 + Math.min(30, profile.fundings.length * 10));
+}
+
+function serviceFit(profile: AcademicProfile): number {
+  const records = profile.service;
+  const distinctCategories = new Set(records.map((r) => r.category)).size;
+  const categoryComponent = Math.min(100, (distinctCategories / 3) * 100);
+
+  const peerReviews = records.reduce((sum, r) => sum + (r.peerReviewCount ?? 0), 0);
+  const peerReviewComponent = Math.min(100, peerReviews * 5);
+
+  const countComponent = Math.min(100, records.length * 20);
+
+  return clamp(0.4 * categoryComponent + 0.3 * peerReviewComponent + 0.3 * countComponent);
+}
+
+function locationFit(position: AcademicPosition, preferred?: string[]): number {
+  if (!preferred || preferred.length === 0) return 70; // neutral
+  if (!position.location) return 60;
+  const loc = normalize(position.location);
+  const matched = preferred.some((p) => loc.includes(normalize(p)) || normalize(p).includes(loc));
+  return matched ? 100 : 40;
+}
+
+/**
+ * Pick a presentation persona (role-family id, see content-model
+ * ACADEMIC_ROLE_FAMILIES) based on what the position emphasises.
+ */
+function suggestRoleFamily(position: AcademicPosition): string {
+  const { researchExpectation: r, teachingExpectation: t } = position;
+  if (r >= t + 15) return 'research-scholar';
+  if (t >= r + 15) return 'teaching-scholar';
+  return 'scholar-educator';
+}
+
+/**
+ * Analyzes the compatibility between a scholar's academic ledger and an
+ * academic position. Stateless and deterministic — no external providers — so
+ * it is trivially testable and safe to call inside a request handler.
+ */
+export class AcademicCompatibilityAnalyzer {
+  analyze(input: AcademicAnalysisInput): AcademicCompatibilityAnalysis {
+    const { position, profile, preferredLocations } = input;
+    const metrics = computeResearchImpact(profile.works);
+
+    const research_fit = researchFit(position, profile, metrics);
+    const teaching_fit = teachingFit(profile);
+    const funding_fit = fundingFit(position, profile);
+    const service_fit = serviceFit(profile);
+    const location_fit = locationFit(position, preferredLocations);
+
+    // Position-driven weighting. The research/teaching/service expectations
+    // (which encode institution type) are normalised into the bulk of the
+    // score; funding and location take fixed slices.
+    const fundingWeight = position.fundingExpected ? 0.15 : 0.05;
+    const locationWeight = 0.1;
+    const triangleWeight = 1 - fundingWeight - locationWeight;
+
+    const expSum =
+      position.researchExpectation + position.teachingExpectation + position.serviceExpectation;
+    // Guard against a degenerate all-zero expectation set.
+    const safeSum = expSum > 0 ? expSum : 1;
+    const wR = position.researchExpectation / safeSum;
+    const wT = position.teachingExpectation / safeSum;
+    const wS = position.serviceExpectation / safeSum;
+
+    const triangleScore = wR * research_fit + wT * teaching_fit + wS * service_fit;
+    const overall_score = clamp(
+      triangleWeight * triangleScore + fundingWeight * funding_fit + locationWeight * location_fit,
+    );
+
+    const strengths: string[] = [];
+    const gaps: string[] = [];
+    const talking_points: string[] = [];
+
+    if (research_fit >= 70) {
+      strengths.push(
+        `Strong research record (h-index ${metrics.hIndex}, ${metrics.totalPublications} publications, ${metrics.totalCitations} citations).`,
+      );
+    } else if (position.researchExpectation >= 50) {
+      gaps.push(
+        `Research profile may be light for a research-weighted line (h-index ${metrics.hIndex}).`,
+      );
+    }
+
+    if (teaching_fit >= 70) {
+      strengths.push(`Demonstrated teaching breadth across ${profile.teaching.length} courses.`);
+    } else if (position.teachingExpectation >= 40) {
+      gaps.push(
+        'Teaching record is thin for a teaching-weighted role; foreground any TA / guest lectures.',
+      );
+    }
+
+    if (position.fundingExpected && funding_fit < 40) {
+      gaps.push(
+        'No external PI funding on record; address grant strategy in the research statement.',
+      );
+    } else if (funding_fit >= 70) {
+      strengths.push('Track record of external grant capture signals research independence.');
+    }
+
+    if (metrics.firstAuthorCount > 0) {
+      talking_points.push(
+        `${metrics.firstAuthorCount} first/sole/corresponding-author works to anchor the research narrative.`,
+      );
+    }
+    const subfieldMatches = position.subfields.filter((s) =>
+      new Set(profile.researchAreas.map(normalize)).has(normalize(s)),
+    );
+    if (subfieldMatches.length > 0) {
+      talking_points.push(`Direct subfield alignment: ${subfieldMatches.join(', ')}.`);
+    }
+    talking_points.push(
+      `Frame the application for a ${position.institutionType} ${position.positionType} context.`,
+    );
+
+    return {
+      position_id: position.id,
+      research_fit,
+      teaching_fit,
+      funding_fit,
+      service_fit,
+      location_fit,
+      overall_score,
+      recommendation: recommend(overall_score),
+      strengths,
+      gaps,
+      talking_points,
+      suggested_role_family: suggestRoleFamily(position),
+      metrics,
+      analysis_date: new Date().toISOString(),
+    };
+  }
+}
+
+/** Factory mirroring createHunterProtocolAgent. */
+export function createAcademicAnalyzer(): AcademicCompatibilityAnalyzer {
+  return new AcademicCompatibilityAnalyzer();
+}

--- a/packages/core/src/academic/index.ts
+++ b/packages/core/src/academic/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Academic Domain — Core
+ *
+ * Pure, framework-free business logic for the academic counterpart to the
+ * Hunter Protocol:
+ *   - research-impact: author-level bibliometrics (h-index, i10-index)
+ *   - academic-analyzer: scholar ⇄ academic-position compatibility scoring
+ */
+
+export { computeHIndex, computeI10Index, computeResearchImpact } from './research-impact';
+
+export {
+  AcademicCompatibilityAnalyzer,
+  createAcademicAnalyzer,
+  type AcademicAnalysisInput,
+} from './academic-analyzer';

--- a/packages/core/src/academic/research-impact.ts
+++ b/packages/core/src/academic/research-impact.ts
@@ -1,0 +1,83 @@
+/**
+ * Research Impact Analysis
+ *
+ * The academic counterpart to market-rate.ts. Where MarketRateAnalyzer turns a
+ * set of salaries into percentile compensation benchmarks, this module turns a
+ * set of scholarly works into author-level bibliometrics (h-index, i10-index,
+ * citation counts) that feed the academic compatibility analyzer.
+ *
+ * Definitions follow the standard literature:
+ *   - h-index: the largest number h such that h publications have each been
+ *     cited at least h times. https://en.wikipedia.org/wiki/H-index
+ *   - i10-index: the number of publications with at least 10 citations
+ *     (introduced by Google Scholar Citations).
+ */
+
+import type { ResearchImpactMetrics, ScholarlyWork } from '@in-midst-my-life/schema';
+
+/**
+ * Compute the h-index from a list of per-work citation counts.
+ *
+ * A scholar has h-index h when h of their works have >= h citations each and
+ * the remaining works have <= h citations. Returns 0 for an empty list.
+ */
+export function computeHIndex(citationCounts: number[]): number {
+  if (citationCounts.length === 0) return 0;
+
+  // Sort descending so the i-th paper (1-indexed) is the i-th most cited.
+  const sorted = [...citationCounts].sort((a, b) => b - a);
+
+  let h = 0;
+  for (let i = 0; i < sorted.length; i++) {
+    const citations = sorted[i]!; // safe: i < length
+    if (citations >= i + 1) {
+      h = i + 1;
+    } else {
+      break;
+    }
+  }
+  return h;
+}
+
+/**
+ * Compute the i10-index: the number of works with at least 10 citations.
+ */
+export function computeI10Index(citationCounts: number[]): number {
+  return citationCounts.filter((c) => c >= 10).length;
+}
+
+/** An author "lead" position carries the most evaluative weight. */
+function isFirstAuthor(work: ScholarlyWork): boolean {
+  return (
+    work.authorPosition === 'first' ||
+    work.authorPosition === 'sole' ||
+    work.authorPosition === 'corresponding'
+  );
+}
+
+/**
+ * Compute the full set of author-level impact metrics from a scholar's works.
+ *
+ * Only counts works that have entered the citation record (published or in
+ * press); manuscripts under review / in preparation accrue no citations and are
+ * excluded from the bibliometric denominators, matching how Scholar profiles
+ * behave.
+ */
+export function computeResearchImpact(works: ScholarlyWork[]): ResearchImpactMetrics {
+  const counted = works.filter((w) => w.status === 'published' || w.status === 'in-press');
+
+  const citationCounts = counted.map((w) => w.citations);
+  const totalCitations = citationCounts.reduce((sum, c) => sum + c, 0);
+  const totalPublications = counted.length;
+
+  return {
+    hIndex: computeHIndex(citationCounts),
+    i10Index: computeI10Index(citationCounts),
+    totalCitations,
+    totalPublications,
+    peerReviewedCount: counted.filter((w) => w.peerReviewed).length,
+    firstAuthorCount: counted.filter(isFirstAuthor).length,
+    meanCitations:
+      totalPublications === 0 ? 0 : Math.round((totalCitations / totalPublications) * 100) / 100,
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,6 +12,7 @@ export * from './errors';
 export * from './jobs';
 export * from './search';
 export * from './hunter';
+export * from './academic';
 
 // Re-export types from server module for TypeScript consumers
 // (Types don't carry runtime dependencies, so safe to export from main entry)

--- a/packages/core/test/academic-analyzer.test.ts
+++ b/packages/core/test/academic-analyzer.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest';
+import { AcademicCompatibilityAnalyzer } from '../src/academic/academic-analyzer';
+import type { AcademicPosition, AcademicProfile, ScholarlyWork } from '@in-midst-my-life/schema';
+
+const uuid = (n: number): string => `00000000-0000-0000-0000-${n.toString().padStart(12, '0')}`;
+
+const pub = (i: number, citations: number): ScholarlyWork => ({
+  id: uuid(i),
+  title: `Paper ${i}`,
+  type: 'journal-article',
+  year: 2018 + (i % 5),
+  citations,
+  status: 'published',
+  peerReviewed: true,
+  authorPosition: 'first',
+});
+
+/** A research-heavy scholar: many well-cited, first-author papers (h-index 10). */
+const researchScholar: AcademicProfile = {
+  researchAreas: ['machine learning', 'nlp'],
+  works: [
+    pub(1, 40),
+    pub(2, 35),
+    pub(3, 30),
+    pub(4, 28),
+    pub(5, 25),
+    pub(6, 22),
+    pub(7, 20),
+    pub(8, 15),
+    pub(9, 12),
+    pub(10, 11),
+  ],
+  fundings: [
+    {
+      id: uuid(100),
+      title: 'CAREER: Foundations',
+      agency: 'NSF',
+      amount: 600_000,
+      currency: 'USD',
+      role: 'principal-investigator',
+      status: 'active',
+      external: true,
+    },
+  ],
+  teaching: [],
+  service: [
+    {
+      id: uuid(200),
+      category: 'disciplinary',
+      role: 'Program Committee',
+      organization: 'ACL',
+      peerReviewCount: 12,
+    },
+  ],
+};
+
+const r1Position: AcademicPosition = {
+  id: uuid(1),
+  title: 'Assistant Professor',
+  institution: 'State R1',
+  institutionType: 'r1-research',
+  positionType: 'tenure-track',
+  researchExpectation: 80,
+  teachingExpectation: 15,
+  serviceExpectation: 5,
+  fundingExpected: true,
+  subfields: ['machine learning'],
+};
+
+const puiPosition: AcademicPosition = {
+  id: uuid(2),
+  title: 'Assistant Professor of Teaching',
+  institution: 'Liberal Arts College',
+  institutionType: 'primarily-undergraduate',
+  positionType: 'teaching-faculty',
+  researchExpectation: 20,
+  teachingExpectation: 70,
+  serviceExpectation: 10,
+  fundingExpected: false,
+  subfields: ['machine learning'],
+};
+
+describe('AcademicCompatibilityAnalyzer', () => {
+  const analyzer = new AcademicCompatibilityAnalyzer();
+
+  it('scores a research scholar highly against a research-weighted R1 line', () => {
+    const result = analyzer.analyze({ position: r1Position, profile: researchScholar });
+    expect(result.research_fit).toBeGreaterThanOrEqual(70);
+    expect(result.overall_score).toBeGreaterThanOrEqual(65);
+    expect(['strong_apply', 'competitive']).toContain(result.recommendation);
+    expect(result.suggested_role_family).toBe('research-scholar');
+  });
+
+  it('applies position-driven weighting (same scholar scores lower at a teaching-weighted PUI)', () => {
+    const r1 = analyzer.analyze({ position: r1Position, profile: researchScholar });
+    const pui = analyzer.analyze({ position: puiPosition, profile: researchScholar });
+    // Research-heavy scholar with no teaching record fares worse where teaching dominates.
+    expect(pui.overall_score).toBeLessThan(r1.overall_score);
+    expect(pui.suggested_role_family).toBe('teaching-scholar');
+  });
+
+  it('flags missing external funding when a line expects grant capture', () => {
+    const unfunded: AcademicProfile = { ...researchScholar, fundings: [] };
+    const result = analyzer.analyze({ position: r1Position, profile: unfunded });
+    expect(result.funding_fit).toBe(20);
+    expect(result.gaps.join(' ')).toMatch(/funding/i);
+  });
+
+  it('does not penalise absent funding when it is not expected', () => {
+    const unfunded: AcademicProfile = { ...researchScholar, fundings: [] };
+    const result = analyzer.analyze({ position: puiPosition, profile: unfunded });
+    expect(result.funding_fit).toBeGreaterThanOrEqual(70);
+  });
+
+  it('rewards exact subfield alignment via a talking point', () => {
+    const result = analyzer.analyze({ position: r1Position, profile: researchScholar });
+    expect(result.talking_points.join(' ')).toMatch(/machine learning/i);
+  });
+
+  it('uses location preferences for the location dimension', () => {
+    const positioned: AcademicPosition = { ...r1Position, location: 'Boston, MA' };
+    const match = analyzer.analyze({
+      position: positioned,
+      profile: researchScholar,
+      preferredLocations: ['Boston'],
+    });
+    const miss = analyzer.analyze({
+      position: positioned,
+      profile: researchScholar,
+      preferredLocations: ['Honolulu'],
+    });
+    expect(match.location_fit).toBeGreaterThan(miss.location_fit);
+  });
+
+  it('embeds computed research metrics in the analysis', () => {
+    const result = analyzer.analyze({ position: r1Position, profile: researchScholar });
+    expect(result.metrics.totalPublications).toBe(10);
+    expect(result.metrics.hIndex).toBe(10);
+  });
+});

--- a/packages/core/test/academic-research-impact.test.ts
+++ b/packages/core/test/academic-research-impact.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeHIndex,
+  computeI10Index,
+  computeResearchImpact,
+} from '../src/academic/research-impact';
+import type { ScholarlyWork } from '@in-midst-my-life/schema';
+
+const work = (over: Partial<ScholarlyWork>): ScholarlyWork => ({
+  id: '00000000-0000-0000-0000-000000000000',
+  title: 'A Work',
+  type: 'journal-article',
+  year: 2020,
+  citations: 0,
+  status: 'published',
+  peerReviewed: true,
+  ...over,
+});
+
+describe('computeHIndex', () => {
+  it('returns 0 for an empty list', () => {
+    expect(computeHIndex([])).toBe(0);
+  });
+
+  it('computes the textbook h-index', () => {
+    // 14 papers each cited 14 times → h-index 14
+    expect(computeHIndex(new Array(14).fill(14))).toBe(14);
+  });
+
+  it('computes h from an uneven citation distribution', () => {
+    // sorted desc [10,8,5,4,3]: 4 papers have >= 4 citations, 5th has only 3
+    expect(computeHIndex([3, 10, 5, 8, 4])).toBe(4);
+  });
+
+  it('is bounded by the number of papers', () => {
+    expect(computeHIndex([100, 100])).toBe(2);
+  });
+});
+
+describe('computeI10Index', () => {
+  it('counts works with at least 10 citations', () => {
+    expect(computeI10Index([9, 10, 11, 100, 0])).toBe(3);
+  });
+});
+
+describe('computeResearchImpact', () => {
+  it('excludes non-citable works from the bibliometric denominators', () => {
+    const works: ScholarlyWork[] = [
+      work({ id: '1'.padStart(36, '0'), citations: 20, status: 'published' }),
+      work({ id: '2'.padStart(36, '0'), citations: 15, status: 'in-press' }),
+      work({ id: '3'.padStart(36, '0'), citations: 0, status: 'under-review' }),
+      work({ id: '4'.padStart(36, '0'), citations: 0, status: 'in-preparation' }),
+    ];
+    const metrics = computeResearchImpact(works);
+    expect(metrics.totalPublications).toBe(2); // published + in-press only
+    expect(metrics.totalCitations).toBe(35);
+    expect(metrics.hIndex).toBe(2);
+    expect(metrics.i10Index).toBe(2);
+    expect(metrics.meanCitations).toBe(17.5);
+  });
+
+  it('counts first/sole/corresponding author works', () => {
+    const works: ScholarlyWork[] = [
+      work({ id: '1'.padStart(36, '0'), authorPosition: 'first', citations: 5 }),
+      work({ id: '2'.padStart(36, '0'), authorPosition: 'corresponding', citations: 5 }),
+      work({ id: '3'.padStart(36, '0'), authorPosition: 'middle', citations: 5 }),
+    ];
+    expect(computeResearchImpact(works).firstAuthorCount).toBe(2);
+  });
+
+  it('returns zeroed metrics for an empty ledger', () => {
+    const metrics = computeResearchImpact([]);
+    expect(metrics.hIndex).toBe(0);
+    expect(metrics.totalPublications).toBe(0);
+    expect(metrics.meanCitations).toBe(0);
+  });
+});

--- a/packages/schema/src/academic.ts
+++ b/packages/schema/src/academic.ts
@@ -1,0 +1,361 @@
+import { z } from 'zod';
+
+/**
+ * Academic Domain Schema
+ *
+ * The academic counterpart to the market-facing Hunter Protocol. Where the
+ * Hunter Protocol matches a candidate to a *job* using compensation and skills,
+ * the academic domain matches a scholar to an *academic position* using
+ * research, teaching, funding, and service — the canonical "research–teaching–
+ * service triangle" that governs faculty evaluation.
+ *
+ * The data model deliberately mirrors recognised external standards so an
+ * academic ledger can round-trip with the wider scholarly ecosystem:
+ *   - ORCID record model (works, fundings, peer-reviews, services, educations)
+ *     https://info.orcid.org/documentation/integration-guide/orcid-record/
+ *   - CRediT contributor roles taxonomy, ANSI/NISO Z39.104-2022
+ *     https://credit.niso.org/
+ *   - Author-level impact metrics (h-index, i10-index)
+ *     https://en.wikipedia.org/wiki/H-index
+ */
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CONTRIBUTOR ROLES — CRediT (ANSI/NISO Z39.104-2022), 14 canonical roles
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const CreditRoleSchema = z.enum([
+  'conceptualization',
+  'data-curation',
+  'formal-analysis',
+  'funding-acquisition',
+  'investigation',
+  'methodology',
+  'project-administration',
+  'resources',
+  'software',
+  'supervision',
+  'validation',
+  'visualization',
+  'writing-original-draft',
+  'writing-review-editing',
+]);
+
+export type CreditRole = z.infer<typeof CreditRoleSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SCHOLARLY WORKS (ORCID "works" — publications, datasets, software, ...)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Subset of ORCID work types most relevant to a CV publications section.
+ * Named `ScholarlyWorkType` (not `PublicationType`) to avoid colliding with the
+ * coarser `PublicationTypeSchema` already exported by the CV schema (cv.ts).
+ */
+export const ScholarlyWorkTypeSchema = z.enum([
+  'journal-article',
+  'conference-paper',
+  'book',
+  'book-chapter',
+  'preprint',
+  'thesis',
+  'dataset',
+  'software',
+  'report',
+  'other',
+]);
+
+export type ScholarlyWorkType = z.infer<typeof ScholarlyWorkTypeSchema>;
+
+/**
+ * Publication status — the lifecycle the most-scrutinised CV section is
+ * sub-divided by (published / in press / under review / in preparation).
+ */
+export const PublicationStatusSchema = z.enum([
+  'published',
+  'in-press',
+  'under-review',
+  'in-preparation',
+]);
+
+export type PublicationStatus = z.infer<typeof PublicationStatusSchema>;
+
+/** Author position is weighed heavily in evaluation (first / corresponding). */
+export const AuthorPositionSchema = z.enum(['first', 'middle', 'last', 'corresponding', 'sole']);
+
+export type AuthorPosition = z.infer<typeof AuthorPositionSchema>;
+
+export const ScholarlyWorkSchema = z.object({
+  id: z.string().uuid(),
+  title: z.string().min(1),
+  type: ScholarlyWorkTypeSchema,
+  /** Journal or conference name (the publication venue). */
+  venue: z.string().optional(),
+  year: z.number().int().min(1500).max(2200),
+  doi: z.string().optional(),
+  url: z.string().url().optional(),
+  /** Citation count — drives the h-index / i10-index metrics. */
+  citations: z.number().int().min(0).default(0),
+  status: PublicationStatusSchema.default('published'),
+  peerReviewed: z.boolean().default(true),
+  authorPosition: AuthorPositionSchema.optional(),
+  coauthorCount: z.number().int().min(0).optional(),
+  /** CRediT contribution roles for this work. */
+  contributorRoles: CreditRoleSchema.array().optional(),
+  tags: z.string().array().optional(),
+});
+
+export type ScholarlyWork = z.infer<typeof ScholarlyWorkSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// FUNDING / GRANTS (ORCID "fundings")
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Role on a grant — external grants where you are PI signal independence. */
+export const FundingRoleSchema = z.enum([
+  'principal-investigator',
+  'co-principal-investigator',
+  'co-investigator',
+  'senior-personnel',
+  'fellow',
+  'consultant',
+]);
+
+export type FundingRole = z.infer<typeof FundingRoleSchema>;
+
+export const FundingStatusSchema = z.enum([
+  'proposed',
+  'under-review',
+  'awarded',
+  'active',
+  'completed',
+  'declined',
+]);
+
+export type FundingStatus = z.infer<typeof FundingStatusSchema>;
+
+export const FundingSchema = z.object({
+  id: z.string().uuid(),
+  title: z.string().min(1),
+  /** Granting agency (NSF, NIH, ERC, Wellcome Trust, ...). */
+  agency: z.string().min(1),
+  grantNumber: z.string().optional(),
+  amount: z.number().min(0).optional(),
+  currency: z.string().default('USD'),
+  role: FundingRoleSchema,
+  status: FundingStatusSchema.default('awarded'),
+  startDate: z.string().optional(),
+  endDate: z.string().optional(),
+  /** Whether the funding source is external to the home institution. */
+  external: z.boolean().default(true),
+});
+
+export type Funding = z.infer<typeof FundingSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TEACHING RECORDS
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const CourseLevelSchema = z.enum([
+  'undergraduate',
+  'graduate',
+  'professional',
+  'continuing-education',
+]);
+
+export type CourseLevel = z.infer<typeof CourseLevelSchema>;
+
+export const CourseFormatSchema = z.enum([
+  'lecture',
+  'seminar',
+  'laboratory',
+  'studio',
+  'online',
+  'hybrid',
+]);
+
+export type CourseFormat = z.infer<typeof CourseFormatSchema>;
+
+export const TeachingRecordSchema = z.object({
+  id: z.string().uuid(),
+  courseCode: z.string().optional(),
+  title: z.string().min(1),
+  institution: z.string().min(1),
+  level: CourseLevelSchema,
+  format: CourseFormatSchema.default('lecture'),
+  term: z.string().optional(),
+  enrollment: z.number().int().min(0).optional(),
+  /** Normalised teaching evaluation score (0–5, e.g. mean course rating). */
+  evaluationScore: z.number().min(0).max(5).optional(),
+  roleAsInstructorOfRecord: z.boolean().default(true),
+});
+
+export type TeachingRecord = z.infer<typeof TeachingRecordSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SERVICE RECORDS (ORCID "services" / "memberships")
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** The three broad categories of academic service. */
+export const ServiceCategorySchema = z.enum(['institutional', 'disciplinary', 'community']);
+
+export type ServiceCategory = z.infer<typeof ServiceCategorySchema>;
+
+export const ServiceRecordSchema = z.object({
+  id: z.string().uuid(),
+  category: ServiceCategorySchema,
+  role: z.string().min(1),
+  organization: z.string().min(1),
+  startDate: z.string().optional(),
+  endDate: z.string().optional(),
+  /** e.g. journal peer-review counts, program-committee membership. */
+  peerReviewCount: z.number().int().min(0).optional(),
+});
+
+export type ServiceRecord = z.infer<typeof ServiceRecordSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// RESEARCH IMPACT METRICS (author-level bibliometrics)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const ResearchImpactMetricsSchema = z.object({
+  /** h-index: h papers each cited at least h times. */
+  hIndex: z.number().int().min(0),
+  /** i10-index: number of works with >= 10 citations (Google Scholar). */
+  i10Index: z.number().int().min(0),
+  totalCitations: z.number().int().min(0),
+  totalPublications: z.number().int().min(0),
+  peerReviewedCount: z.number().int().min(0),
+  firstAuthorCount: z.number().int().min(0),
+  /** Mean citations per published work. */
+  meanCitations: z.number().min(0),
+});
+
+export type ResearchImpactMetrics = z.infer<typeof ResearchImpactMetricsSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ACADEMIC POSITION (the "job" analogue — what a scholar is matched against)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Institution type strongly determines how research/teaching/service are
+ * weighed (R1 → research-dominant; PUI / community college → teaching-dominant).
+ */
+export const InstitutionTypeSchema = z.enum([
+  'r1-research',
+  'r2-research',
+  'liberal-arts',
+  'primarily-undergraduate',
+  'community-college',
+  'research-institute',
+  'industry-lab',
+]);
+
+export type InstitutionType = z.infer<typeof InstitutionTypeSchema>;
+
+export const PositionTypeSchema = z.enum([
+  'tenure-track',
+  'tenured',
+  'teaching-faculty',
+  'research-faculty',
+  'postdoctoral',
+  'visiting',
+  'adjunct',
+  'lecturer',
+]);
+
+export type PositionType = z.infer<typeof PositionTypeSchema>;
+
+export const AcademicPositionSchema = z.object({
+  id: z.string().uuid(),
+  title: z.string().min(1),
+  institution: z.string().min(1),
+  department: z.string().optional(),
+  institutionType: InstitutionTypeSchema,
+  positionType: PositionTypeSchema,
+  /** Teaching load notation, e.g. "2-2" (courses per term per year). */
+  teachingLoad: z.string().optional(),
+  /** Relative expectation weightings (0–100); used to tilt the fit scoring. */
+  researchExpectation: z.number().min(0).max(100).default(50),
+  teachingExpectation: z.number().min(0).max(100).default(30),
+  serviceExpectation: z.number().min(0).max(100).default(20),
+  /** Whether the role expects external grant capture. */
+  fundingExpected: z.boolean().default(false),
+  /** Research subfields the department is hiring into. */
+  subfields: z.string().array().default([]),
+  location: z.string().optional(),
+  startDate: z.string().optional(),
+  applicationDeadline: z.string().optional(),
+});
+
+export type AcademicPosition = z.infer<typeof AcademicPositionSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ACADEMIC PROFILE (the scholar's ledger — the candidate side of the match)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const AcademicProfileSchema = z.object({
+  profileId: z.string().uuid().optional(),
+  /** Subfields the scholar works in — matched against position subfields. */
+  researchAreas: z.string().array().default([]),
+  works: ScholarlyWorkSchema.array().default([]),
+  fundings: FundingSchema.array().default([]),
+  teaching: TeachingRecordSchema.array().default([]),
+  service: ServiceRecordSchema.array().default([]),
+  /** Years since first appointment / PhD — proxy for career stage. */
+  yearsActive: z.number().min(0).optional(),
+});
+
+export type AcademicProfile = z.infer<typeof AcademicProfileSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ACADEMIC COMPATIBILITY ANALYSIS (mirror of CompatibilityAnalysis)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const AcademicRecommendationSchema = z.enum([
+  'strong_apply',
+  'competitive',
+  'reach',
+  'developmental',
+  'skip',
+]);
+
+export type AcademicRecommendation = z.infer<typeof AcademicRecommendationSchema>;
+
+export const AcademicCompatibilityAnalysisSchema = z.object({
+  position_id: z.string().uuid(),
+
+  // Dimensional fit scores (0–100), mirroring the research–teaching–service triangle.
+  research_fit: z.number().min(0).max(100),
+  teaching_fit: z.number().min(0).max(100),
+  funding_fit: z.number().min(0).max(100),
+  service_fit: z.number().min(0).max(100),
+  location_fit: z.number().min(0).max(100),
+
+  overall_score: z.number().min(0).max(100),
+  recommendation: AcademicRecommendationSchema,
+
+  strengths: z.string().array(),
+  gaps: z.string().array(),
+  /** Things to foreground in a cover letter / job talk. */
+  talking_points: z.string().array(),
+
+  /** Recommended role-family persona to present this candidacy through. */
+  suggested_role_family: z.string().optional(),
+
+  metrics: ResearchImpactMetricsSchema,
+  analysis_date: z.string(),
+});
+
+export type AcademicCompatibilityAnalysis = z.infer<typeof AcademicCompatibilityAnalysisSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DOMAIN BUNDLE (mirrors HunterProtocolSchema)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const AcademicDomainSchema = z.object({
+  profile: AcademicProfileSchema,
+  positions: AcademicPositionSchema.array(),
+  analyses: AcademicCompatibilityAnalysisSchema.array(),
+});
+
+export type AcademicDomain = z.infer<typeof AcademicDomainSchema>;

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -18,6 +18,7 @@ export * from './verification';
 export * from './narrative';
 export * from './jobs';
 export * from './hunter-protocol';
+export * from './academic';
 export * from './collaboration';
 export * from './messaging';
 export * from './billing';

--- a/packages/schema/test/academic.test.ts
+++ b/packages/schema/test/academic.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import {
+  AcademicPositionSchema,
+  AcademicProfileSchema,
+  CreditRoleSchema,
+  FundingSchema,
+  ScholarlyWorkSchema,
+} from '../src/index';
+
+describe('Academic domain schemas', () => {
+  describe('CreditRoleSchema', () => {
+    it('encodes the 14 CRediT contributor roles (ANSI/NISO Z39.104-2022)', () => {
+      expect(CreditRoleSchema.options).toHaveLength(14);
+      expect(CreditRoleSchema.safeParse('conceptualization').success).toBe(true);
+      expect(CreditRoleSchema.safeParse('not-a-role').success).toBe(false);
+    });
+  });
+
+  describe('ScholarlyWorkSchema', () => {
+    it('applies defaults for citations, status and peer-review', () => {
+      const parsed = ScholarlyWorkSchema.parse({
+        id: '00000000-0000-0000-0000-000000000001',
+        title: 'On Inverted Interviews',
+        type: 'journal-article',
+        year: 2024,
+      });
+      expect(parsed.citations).toBe(0);
+      expect(parsed.status).toBe('published');
+      expect(parsed.peerReviewed).toBe(true);
+    });
+
+    it('rejects an out-of-range year', () => {
+      const result = ScholarlyWorkSchema.safeParse({
+        id: '00000000-0000-0000-0000-000000000001',
+        title: 'Time Travel',
+        type: 'journal-article',
+        year: 99999,
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('FundingSchema', () => {
+    it('validates an external PI grant', () => {
+      const result = FundingSchema.safeParse({
+        id: '00000000-0000-0000-0000-000000000002',
+        title: 'CAREER Award',
+        agency: 'NSF',
+        role: 'principal-investigator',
+        amount: 500000,
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.currency).toBe('USD');
+        expect(result.data.external).toBe(true);
+      }
+    });
+  });
+
+  describe('AcademicPositionSchema', () => {
+    it('defaults the research/teaching/service expectation triangle', () => {
+      const parsed = AcademicPositionSchema.parse({
+        id: '00000000-0000-0000-0000-000000000003',
+        title: 'Assistant Professor',
+        institution: 'State University',
+        institutionType: 'r1-research',
+        positionType: 'tenure-track',
+      });
+      expect(parsed.researchExpectation).toBe(50);
+      expect(parsed.teachingExpectation).toBe(30);
+      expect(parsed.serviceExpectation).toBe(20);
+      expect(parsed.subfields).toEqual([]);
+    });
+  });
+
+  describe('AcademicProfileSchema', () => {
+    it('accepts an empty ledger via defaults', () => {
+      const parsed = AcademicProfileSchema.parse({});
+      expect(parsed.works).toEqual([]);
+      expect(parsed.fundings).toEqual([]);
+      expect(parsed.teaching).toEqual([]);
+      expect(parsed.service).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces the Inverted Interview engine for a second domain — the **academy** —
mirroring the market-facing **Hunter Protocol** layer-for-layer. Where the
Hunter Protocol matches a candidate to a *job*, this matches a scholar to an
*academic position* on the research–teaching–service triangle.

This responds to the seeding directive (*review internal precedent processes;
study external instances; surface internal + external surfaces; domain
implementations: academic, market*) as a full code build with web-researched,
cited external grounding.

## What landed (layer-for-layer mirror of the market domain)

| Layer | File | Precedent it mirrors |
|---|---|---|
| Schema | `packages/schema/src/academic.ts` | `hunter-protocol.ts` |
| Core — bibliometrics | `packages/core/src/academic/research-impact.ts` | `market-rate.ts` |
| Core — fit engine | `packages/core/src/academic/academic-analyzer.ts` | `compatibility-analyzer.ts` |
| Content-model | `packages/content-model/src/academic.ts` | `role-families.ts` |
| API | `apps/api/src/routes/academic.ts` | `marketplace.ts` |
| Docs | `docs/features/academic-domain/ACADEMIC-DOMAIN.md` | — |

### Highlights
- **Anchored to real external standards** (cited in the docs): ORCID record
  model, CRediT contributor roles (ANSI/NISO Z39.104-2022), h-index / i10-index,
  academic-CV section conventions, and the R1-vs-PUI faculty job market.
- **Position-driven scoring**: the research/teaching/service expectation triangle
  on each `AcademicPosition` (which encodes institution type) drives the weights,
  so the *same scholar* scores strongly at a research-weighted R1 line and weakly
  at a teaching-weighted PUI line.
- **Non-invasive personas**: academic personas are expressed as role-family mask
  blends rather than new mask types, leaving the 16-mask affinity matrices intact.

### API surface
- `GET  /academic/taxonomy`
- `POST /academic/research-impact`
- `POST /academic/analyze-position`
- `POST /academic/cv`

## Tests
26 new tests, all green, plus no regressions in the touched packages:
- schema suite: 83 passed · core suite: 284 passed · content-model suite: 175 passed
- api: academic routes 5 passed; marketplace + masks smoke 23 passed
- All layers pass `tsc --noEmit` typecheck and ESLint/Prettier.

## Note for maintainers (pre-existing, not introduced here)
`packages/core` and `packages/content-model` fail their `tsc -p .` **build**
(`error TS6059 … not under rootDir`) on a clean tree, because the inherited root
`paths` resolves `@in-midst-my-life/*` to `src`. This is unrelated to this PR
(reproduced via `git stash`), and does not affect runtime — both packages are
consumed from source (`"main": "./src/index.ts"`), so resolution and tests work.
Correctness here was therefore gated on `tsc --noEmit` typecheck + tests. Happy
to open a separate fix (clearing inherited `paths` in those build tsconfigs) if
wanted.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LaPLebFYmwT7tL68xn2yvg)_