### PR TITLE
heal: restore FOUND-00{1..5} foundational provenance (PII redacted)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,10 +33,3 @@ next-env.d.ts
 Thumbs.db
 .lh/
 .vercel
-
-# removed inadvertently-committed local session artifacts (PII containment)
-docs/archived/foundations/FOUND-001-blockchain-cv-analogy.md
-docs/archived/foundations/FOUND-002-blockchain-cv-vs-resume.md
-docs/archived/foundations/FOUND-003-meta-latin-etymology.md
-docs/archived/foundations/FOUND-004-identity-narrative-questions.md
-docs/archived/foundations/FOUND-005-prospecting-research-prompts.md

--- a/docs/archived/foundations/FOUND-001-blockchain-cv-analogy.md
+++ b/docs/archived/foundations/FOUND-001-blockchain-cv-analogy.md
@@ -1,0 +1,47 @@
+> **⚠️ ARCHIVED — HISTORICAL SNAPSHOT**
+> This document reflects the state at time of writing and may not match current implementation.
+> For current status, see [`docs/FEATURE-AUDIT.md`](../../FEATURE-AUDIT.md).
+
+# Blockchain as CV analogy
+
+> **Historical Document** — This is an archived foundational design document. The implementation has evolved since this was written. See `docs/README.md` for current documentation and `docs/FEATURE-AUDIT.md` for current feature status.
+
+**User:** [redacted]  
+**Created:** 11/25/2025 14:24:58  
+**Updated:** 11/25/2025 14:34:38  
+**Exported:** 12/26/2025 13:32:27  
+**Link:** [redacted — personal conversation link]  
+
+## Prompt:
+Is a CV equivalent in functionality to a ledger/blockchain? what then would be a Resume equivalent?
+
+2/2
+
+## Response:
+Short answer:
+
+A CV is much closer to a blockchain-style ledger than a résumé is.  
+A résumé is more like a compressed “current state” snapshot derived from that ledger.
+
+Expanded:
+
+A CV behaves like a personal career ledger. It is longitudinal, append-only in spirit, and aims to preserve as much of the historical record as is practical: every degree, every role, every publication, ideally in chronological order. Functionally, that is very similar to a blockchain’s full ledger, which records every transaction from genesis to the present so that the full history is auditable and reconstructable.
+
+A résumé, by contrast, is a selective state representation. It is curated for a specific purpose, audience, or query. Instead of exposing the entire chain of transactions, it exposes the subset that proves a particular claim: “I am qualified for this role,” “I belong in this program,” etc. In blockchain terms, you can think of a résumé as one of the following:
+
+1.  A pruned chain or light client view that keeps only headers or relevant segments, not the full transaction history.
+2.  A state snapshot: “Here is the current balance and key holdings” rather than “here is every transaction that got us here.”
+3.  A zero-knowledge proof–style artifact: “Here is just enough evidence to convince you I meet your constraints, without revealing all underlying data.”
+
+So if you treat “CV : résumé” as “full ledger : query-optimized proof,” then:
+
+The CV is the canonical append-only record, closest in functionality to the blockchain itself.  
+The résumé is a derived view: a compressed, context-specific, and sometimes ephemeral representation of that underlying chain, tuned to a particular validator (employer, committee, collaborator).
+
+If you want to push the analogy further for system design:  
+You would store and maintain the CV as the master log, and generate many different résumés as on-demand “proof objects” built from that log, each tailored to a specific verification context.
+
+
+
+---
+Powered by [ChatGPT Exporter](https://www.chatgptexporter.com)

--- a/docs/archived/foundations/FOUND-002-blockchain-cv-vs-resume.md
+++ b/docs/archived/foundations/FOUND-002-blockchain-cv-vs-resume.md
@@ -1,0 +1,121 @@
+> **⚠️ ARCHIVED — HISTORICAL SNAPSHOT**
+> This document reflects the state at time of writing and may not match current implementation.
+> For current status, see [`docs/FEATURE-AUDIT.md`](../../FEATURE-AUDIT.md).
+
+# Blockchain as CV!resume
+
+> **Historical Document** — This is an archived foundational design document. The implementation has evolved since this was written. See `docs/README.md` for current documentation and `docs/FEATURE-AUDIT.md` for current feature status.
+
+**User:** [redacted]  
+**Created:** 11/25/2025 14:34:55  
+**Updated:** 11/25/2025 14:35:21  
+**Exported:** 12/26/2025 13:32:44  
+**Link:** [redacted — personal conversation link]  
+
+## Prompt:
+Short version:
+A blockchain is already behaving like a CV/resume, just for data and value instead of a person.
+
+Longer, mapped cleanly.
+
+1. Conceptual analogy
+   A CV is a chronological, tamper-resistant record of what you have done.
+   A blockchain is a chronological, tamper-resistant record of what the network has done.
+   So: “blockchain : network activity :: CV/resume : person’s activity.”
+
+2. Human CV/resume, but “on-chain”
+   If you mean “what is the blockchain-native version of a CV/resume for a person?”, think of a stack:
+
+a) Decentralized identity profile
+Think: your “name card” on chain.
+Primitives: DID, ENS-like name, main wallet address.
+Env placeholder: $DID_MAIN, $PRIMARY_ADDRESS.
+
+b) Verifiable credentials (VCs)
+Employers, schools, collaborators issue signed attestations instead of lines on a PDF.
+Examples: “Completed course X”, “Employed at org Y from date A–B”, cryptographically signed and checkable.
+Env placeholder: $VC_REGISTRY_URL.
+
+c) Reputation / soulbound layer
+Tokens or attestations that are non-transferable and bound to you: grants, awards, roles, trust scores.
+Env placeholder: $SBT_CONTRACT_ADDRESS.
+
+d) Portfolio content off-chain, proofs on-chain
+Actual work (PDFs, videos, code, writing) lives in IPFS/GitHub/etc., with hashes anchored on-chain so anyone can verify nothing changed.
+Env placeholders: $PORTFOLIO_IPFS_CID, $GITHUB_PROFILE_URL.
+
+3. “CV vs resume” inside the blockchain metaphor
+   If you want a tighter analogy:
+
+Full CV equivalent
+The raw ledger of all your verifiable credentials and reputation events across a long period, address-by-address. Think “complete on-chain history + linked proofs.”
+Env placeholder: $ON_CHAIN_CV_INDEX.
+
+Resume equivalent
+A curated view or dashboard that selects and formats a subset of that history for a specific purpose (job, grant, residency). Think a front-end or profile page that queries the above and presents only what matters to a given audience.
+Env placeholder: $ON_CHAIN_RESUME_DASHBOARD_URL.
+
+4. One-sentence synthesis
+   Traditional CV/resume is a self-reported Word/PDF file.
+   Blockchain-equivalent CV/resume is a queryable, cryptographically verifiable trail of identity, credentials, and works, anchored in a public ledger and rendered as a human-readable profile.
+
+## Response:
+Below is your draft, tightened, systematized, and made cleaner without changing the logic. It is suitable as a “short–long mapping” that stands on its own and can also serve as a conceptual scaffold for further work in your project.
+
+* * *
+
+**Short version**  
+A blockchain already functions like a CV/resume—just for data, value, and state transitions instead of a person’s life and work.
+
+* * *
+
+**Longer version (clean mapping)**
+
+1.  **Conceptual analogy**
+    *   A CV is a chronological, tamper-resistant record of what a person has done.
+    *   A blockchain is a chronological, tamper-resistant record of what a network has done.  
+        Therefore:  
+        **blockchain : network activity :: CV/resume : individual activity.**
+2.  **Human CV/resume, but “on-chain”**  
+    Model it as a four-layer stack:
+    **a) Decentralized identity (DID layer)**  
+    Your canonical identity anchor.  
+    Components: DID, ENS-style handle, primary wallet.  
+    Placeholders: `$DID_MAIN`, `$PRIMARY_ADDRESS`.
+    **b) Verifiable credentials (VC layer)**  
+    Replaces self-written bullet points with cryptographically signed attestations.  
+    Examples: course completions, employment periods, memberships, collaborations.  
+    Placeholders: `$VC_REGISTRY_URL`.
+    **c) Reputation / soulbound layer**  
+    Non-transferable acknowledgments: awards, grants, roles, trust metrics.  
+    Operates as your durable, provable “reputation substrate.”  
+    Placeholders: `$SBT_CONTRACT_ADDRESS`.
+    **d) Portfolio content off-chain, proofs on-chain**  
+    Actual artifacts (PDFs, code, video, writing) stored off-chain;  
+    integrity proofs (hashes) anchored on-chain.  
+    Placeholders: `$PORTFOLIO_IPFS_CID`, `$GITHUB_PROFILE_URL`.
+3.  **“CV vs. resume” inside the blockchain metaphor**
+    **On-chain CV (full record)**  
+    The complete set of all verifiable credentials, attestations, and reputation events linked to your DID.  
+    Equivalent to a full academic CV: comprehensive, exhaustive, longitudinal.  
+    Placeholder: `$ON_CHAIN_CV_INDEX`.
+    **On-chain resume (curated view)**  
+    A filtered, purpose-specific presentation layer.  
+    Essentially a UI that queries your on-chain CV and selects what is relevant for a specific reviewer.  
+    Placeholder: `$ON_CHAIN_RESUME_DASHBOARD_URL`.
+4.  **One-sentence synthesis**  
+    A traditional CV/resume is self-reported text.  
+    An on-chain CV/resume is a cryptographically verifiable identity + credential + work-trail, queryable directly from the ledger and rendered as a profile for human interpretation.
+
+* * *
+
+If you want, I can convert this into:
+
+*   A diagrammatic schema.
+*   A set of modular definitions for a paper or talk.
+*   A version using Latin meta-terminology to parallel the dramaturgy thread from your earlier prompt.
+
+
+
+---
+Powered by [ChatGPT Exporter](https://www.chatgptexporter.com)

--- a/docs/archived/foundations/FOUND-003-meta-latin-etymology.md
+++ b/docs/archived/foundations/FOUND-003-meta-latin-etymology.md
@@ -1,0 +1,440 @@
+> **⚠️ ARCHIVED — HISTORICAL SNAPSHOT**
+> This document reflects the state at time of writing and may not match current implementation.
+> For current status, see [`docs/FEATURE-AUDIT.md`](../../FEATURE-AUDIT.md).
+
+# Meta Latin in drama
+
+> **Historical Document** — This is an archived foundational design document. The implementation has evolved since this was written. See `docs/README.md` for current documentation and `docs/FEATURE-AUDIT.md` for current feature status.
+
+**User:** [redacted]  
+**Created:** 11/25/2025 11:47:57  
+**Updated:** 11/25/2025 14:34:26  
+**Exported:** 12/26/2025 13:31:47  
+**Link:** [redacted — personal conversation link]  
+
+## Prompt:
+Meta Latin phrases in  drama
+
+## Response:
+Thought for 34s
+
+Here are Latin phrases that are especially “meta” in relation to drama, theatre, and narrative construction, with quick notes on how they function.
+
+Dramatis personae – “the persons of the drama.”  
+Traditional heading for the cast list. Using it inside a script, on stage, or in a program instantly frames the work as aware of itself as a constructed play with roles rather than “real” people.
+
+Deus ex machina – “god from the machine.”  
+Originally a literal god lowered by crane in ancient theatre; now shorthand for an artificial, contrived solution to a plot problem. When characters name it, they are commenting on the mechanics of the story they are inside.
+
+In medias res – “into the middle of things.”  
+Describes a narrative that starts mid-action. A character or narrator invoking it can foreground the structure of the story (“we begin in medias res…”) and break the illusion of seamless reality.
+
+Theatrum mundi – “the theatre of the world.”  
+The world as a stage, everyone playing roles. When used in drama, it turns the play into a commentary on performance itself, suggesting that the characters’ “acting” mirrors the audience’s everyday role-playing.
+
+Persona / personae – “mask; role; character.”  
+Originally the actor’s mask, then the role, then the psychological “self” we present. Having a character refer to their “persona” inside a play directly points to the gap between actor, character, and social role.
+
+Exit / exeunt – “(he/she) leaves” / “(they) leave.”  
+Stage directions in Latin. When spoken aloud or projected onstage (rather than just printed), they make the script itself visible, turning blocking into a meta-joke or self-conscious device.
+
+Finis coronat opus – “the end crowns the work.”  
+A closing motto that comments on endings as the place where the whole structure is judged. Used in a final speech or epilogue, it makes the ending itself part of the play’s argument about narrative form.
+
+Ars est celare artem – “the art is to conceal art.”  
+A favorite in discussions of realism vs. theatricality. A character, director figure, or chorus using this line is explicitly debating whether theatre should hide its constructed nature or flaunt it.
+
+Hic et nunc – “here and now.”  
+When a character emphasizes hic et nunc, it can blur the line between fictional time and the audience’s present, calling attention to the live moment of performance.
+
+Prologus / epilogus – “prologue / epilogue.”  
+More labels than phrases, but when invoked inside a scene (“this is our prologus,” “let this stand as epilogus”), they signal an awareness of dramatic architecture: beginnings, endings, frames.
+
+If you tell me what kind of drama you are working with (classical adaptation, contemporary meta-play, film script, etc.), I can tailor a set of Latin meta-lines that would sit naturally in your dialogue or stage directions.
+
+## Prompt:
+Resume and CV Latin analysis
+
+2/2
+
+## Response:
+Thought for 16s
+
+I will treat “résumé” and “curriculum vitae” as if you asked: what do these phrases mean in Latin terms, and what do they imply conceptually about the self and its representation.
+
+1.  Résumé
+
+Etymology  
+“Résumé” is French, but ultimately from Latin.  
+Latin root: resumere = re- (“again, back”) + sumere (“to take up, to assume”).  
+So at the deepest level, a résumé is “a thing taken up again, taken back together,” i.e., a re-collected or taken-up-again version of something larger.
+
+Conceptual implications  
+A résumé is therefore not your life; it is a re-taken fragment of it. The act of “resuming” implies:  
+You stop a larger flow (your full life, entire career), then you pick it up again in a compressed, restartable form.  
+You decide what is “resumed” and what is left in pause, omission, or silence.  
+Formally, this legitimizes compression, omission, intense selection, and even abruptness or ellipsis as intrinsic to a résumé. You are not lying; you are “resuming” a life narrative after a cut.
+
+Narrative logic  
+A résumé, in Latin terms, is a summary that functions as a jump-cut. It assumes:  
+Prior context is huge and mostly invisible.  
+The document is a re-entry point into that longer story, designed for a very specific audience (employer, curator, etc.).  
+So its “truth” lies in how well it re-starts your story, not in how exhaustively it covers it.
+
+2.  Curriculum vitae
+
+Literal Latin  
+Curriculum vitae is fully Latin.  
+Curriculum: a “running,” “course,” “race,” or “track” (from currere, “to run”). Neuter noun, here in the nominative singular.  
+Vitae: genitive singular of vita, “life” = “of life.”  
+Literal translation: “course of life” or “the running of a life.”
+
+Grammatical structure  
+Curriculum (N. sg.) = “the course / race / track.”  
+Vitae (Gen. sg.) = “of life.”  
+It names your life as a path, sequence, or trajectory, not just a static list. There is motion and duration built into the phrase.
+
+Conceptual implications  
+Calling the document a curriculum vitae frames you as:  
+A runner on a specific track, with visible stages, laps, and milestones.  
+A life with continuity and progression, not just disconnected achievements.  
+The genre of the CV, in Latin terms, is closer to an annotated timeline or chronicle of “the path my life has run so far.”
+
+Narrative logic  
+A CV wants to show:  
+Sequence: what came before what.  
+Continuity: how one phase leads into another (even if that link is implicit).  
+Accumulation: the total course, not just a highlight reel.  
+So a CV naturally supports full academic histories, long lists of publications, ongoing projects, etc. It is structurally comfortable with length and slow accretion.
+
+3.  Résumé vs Curriculum vitae as Latin-conceptual opposites
+
+If you use the Latin roots as a kind of conceptual design spec:
+
+Résumé = resumption.  
+You are compressing and jumping back into your life story at a strategically chosen point. It emphasizes:  
+Selection over completeness.  
+Present relevance over total history.  
+Impact snapshots over continuous narrative.
+
+Curriculum vitae = life-course.  
+You are mapping and exposing the run of your life. It emphasizes:  
+Continuity over interruption.  
+Historical depth over immediate punch.  
+Process, evolution, and duration over highlight.
+
+In other words:  
+Résumé: “Here is the version of my story that gets us back into action right now.”  
+Curriculum vitae: “Here is the course my life has run; walk it with me, step by step.”
+
+4.  How this Latin analysis can shape your documents
+
+If you want to design documents that actually embody their names:
+
+For a résumé, lean into resumere:  
+Treat each section as a “pickup point” from a longer story.  
+Use sharp, concentrated statements that feel like re-entry vectors.  
+Let omission be intentional and aggressive; you are restarting, not archiving.
+
+For a curriculum vitae, lean into curriculum vitae:  
+Organize strictly by chronology so the “course” is visible.  
+Highlight transitions (from one role, field, or discipline to another) as turns in the track.  
+Allow scope: long lists, appendices, and full history belong here.
+
+5.  Meta layer: self as drama
+
+Connecting back to your interest in drama and meta-language:
+
+Résumé:  
+Analogous to a “Previously on…” recap in a series. It is a paratextual device that lets the audience (employer, collaborator) reenter mid-series.
+
+Curriculum vitae:  
+Analogous to a “Complete Performance History” in a program or an archival dossier for a character or performer. It documents the whole run.
+
+If you tell me what kind of persona you want to project (scholar, experimental artist, systems architect, etc.), I can use these Latin logics to design parallel résumé and CV templates that are formally consistent with resumere and curriculum vitae at the structural and language level.
+
+## Prompt:
+I want to project the whole rogue's gallery, one mask as a filter toggled at a time
+
+## Response:
+Thought for 43s
+
+Think of your documents as one big Latin theatre file system.
+
+You have: one curriculum vitae for the whole troupe, and many resumés, each tied to a single mask.
+
+I. Core frame: curriculum vitae multiplex
+
+Name the system:
+
+curriculum\_vitae\_multiplex  
+“the multi-track course of life”
+
+Inside that, define:
+
+Persona = the mask.  
+Persona principalis = the underlying you (the actor).  
+Resumé = the “resumed” version of the vitae, filtered through one persona.  
+Tabula personarum = the index of all masks, your rogue’s gallery.
+
+The rule: you record experience once in the shared CV, then each resumé is a filtered view of that same data.
+
+II. File and environment layout
+
+Use a small, stable layout tied to your dev home.
+
+Example environment variables:
+
+export DEV\_HOME="/Volumes/4444-iivii"  
+export GALLERY\_HOME="$DEV\_HOME/rogues\_gallery"  
+export CV\_MASTER="$GALLERY\_HOME/curriculum\_vitae\_multiplex.md"  
+export MASK\_INDEX="$GALLERY\_HOME/tabula\_personarum.csv"
+
+Each mask gets its own view file, generated from the same source:
+
+export MASK\_VIEWS="$GALLERY\_HOME/personae"  
+Example individual view paths:  
+$MASK\_VIEWS/persona\_scholar\_resume.md  
+$MASK\_VIEWS/persona\_artist\_resume.md  
+$MASK\_VIEWS/persona\_architect\_resume.md
+
+III. Tabula personarum: the rogue’s gallery index
+
+Keep this as a CSV or markdown table you can sort and filter. For example:
+
+| mask\_id | nomen\_personae | everyday\_name | role\_vector | tone\_register | visibility\_scope | motto\_latin |
+| --- | --- | --- | --- | --- | --- | --- |
+| 01 | Persona Sapiens | Scholar | research, teaching | precise, analytic | academia, institutions | Finis coronat opus |
+| 02 | Persona Fabulator | Story-engineer | fiction, narrative | experimental, mythic | art, publishing | Theatrum mundi |
+| 03 | Persona Mechanica | Systems Architect | code, infra, tooling | rigorous, schematic | tech, collab dev | Ars est celare artem |
+| 04 | Persona Errans | Rogue / Trickster | hybrid, liminal | playful, transgressive | special projects | In medias res |
+
+You can extend with columns like primary\_media, key\_tags, canonical\_color, etc.
+
+IV. Master CV template (curriculum\_vitae\_multiplex.md)
+
+This file is the one true source. Every entry must know which masks can claim it.
+
+Skeleton:
+
+Title line: Curriculum Vitae Multiplex
+
+Praefatio (short paragraph stating that this CV is the total course of life, and that all resumés are filtered resumptions of this file.)
+
+Axis Vitae (chronological backbone)  
+Use entries like this, each tagged:
+
+\[YYYY–YYYY\] Role Title  
+Institution / Org  
+Two to four lines of description.  
+Tags: personae={01,03}; domains={teaching, writing}; media={text}
+
+Opera Selecta (selected works and outputs)  
+For each work:
+
+Title of work  
+Venue / platform, year  
+Short description and impact.  
+Tags: personae={02,04}; domains={fiction, hybrid}; media={text, performance}
+
+Appendices (publications, exhibitions, talks, code, commissions, etc.)  
+Everything still tagged with personae and domains.
+
+The key is the tags line. You can make it machine-friendly, for example:
+
+Tags: personae=\[01,03\]; domains=\[teaching,writing\]; media=\[text\]
+
+V. Mask-specific resumé template (one mask at a time)
+
+Each resumé is a lens, not a separate truth. Template:
+
+Title line: Resumé: Persona Fabulator
+
+Subheading: dramatis persona: fabulator in theatrum mundi  
+Optional epigraph in Latin that matches the mask’s vibe.
+
+Section: Intentio  
+One or two sentences describing what this mask is for.  
+Example: “This resumé resumes the course of life as it pertains to narrative design, experimental fiction, and mythic systems.”
+
+Section: Qualificatio (summary)  
+Three to five dense lines that capture this persona’s arc, using only entries from the master CV whose personae tag includes this mask\_id.
+
+Section: Experientia Selecta  
+Reverse-chronological roles, but only entries tagged for this persona. Same underlying text as the master CV, just selected.
+
+Section: Opera Selecta  
+Selected works where the mask tag matches. Brief, high-impact descriptions.
+
+Section: Educatio  
+Education, again filtered to what matters for this persona, but all pulled from the shared CV text.
+
+Section: Appendix Brevis  
+Optional compressed list of other relevant roles or works, still all drawn from the master file.
+
+VI. Operational protocol: toggling masks
+
+The concept is: you never write separate lives; you write one life with multiple personae flags, then “toggle” which flags are visible.
+
+Concrete workflow:
+
+First, update CV\_MASTER with new roles and works, making sure each one has a personae tag line that includes the relevant mask\_ids.
+
+Second, update MASK\_INDEX if you introduce a new mask or change its description or motto.
+
+Third, generate a resumé by choosing a mask\_id, then filtering CV\_MASTER to show only entries where personae includes that id, arranged in resumé order. You can do this by hand at first; later it can be scripted.
+
+Fourth, give each resumé a clear Latin-framed header, so anyone reading it understands this is one mask of a larger theatrum mundi.
+
+VII. Latin phrasing you can drop directly into the documents
+
+To make the meta explicit:
+
+At top of CV\_MASTER:  
+“Theatrum mundi: hic totus curriculum vitae multiplex continetur; resumé personarum sunt tantum variae resumptiones huius cursus.”
+
+Translation in plain English under it if you like.
+
+At top of each resumé:  
+“Dramatis persona: \[name\]. Haec resumé est resumptio selecta ex curriculum vitae multiplex, per hanc personam filtrata.”
+
+If you tell me three to five concrete masks you actually want to use (for example: scholar, experimental artist, infrastructure engineer, horror writer, educator), I can fill in a ready-to-paste tabula\_personarum row set and one full resumé template instantiated for a specific mask.
+
+## Prompt:
+Different mask & different stages
+
+## Response:
+Thought for 43s
+
+Think of it this way: same actor, many masks, and each mask plays differently depending on which stage and which moment of the life-run it appears on.
+
+I will give you a reusable schema you can drop into your CV / résumé system: one axis for masks, one for life-stages, one for “stages” in the theatrical sense (contexts, audiences).
+
+1.  Axes: actor, masks, stages
+
+Subiectum  
+This is you, the underlying actor. It never changes.
+
+Personae  
+These are your masks. Each one is a filter on the same underlying life. For example:  
+Persona Sapiens (scholar)  
+Persona Mechanica (systems / infra)  
+Persona Fabulator (narrative / myth)  
+Persona Errans (rogue / experimental)
+
+Aetas  
+Temporal stages of your life / work. Example Latin labels:  
+Aetas Primaria = formative stage (training, early experiments, “origin story”)  
+Aetas Media = early career consolidation (first serious outputs, first stable roles)  
+Aetas Multiplex = parallel tracks and hybridization (multiple masks active, cross-overs)  
+Aetas Transitus = pivot / metamorphosis stages (big shifts, reinventions)
+
+Scaenae  
+Literal or metaphorical “stages” where you perform the mask. For example:  
+Scaena Academica = classrooms, conferences, journals  
+Scaena Technica = repos, infra, dev orgs  
+Scaena Artistica = galleries, festivals, publications, screenings  
+Scaena Civica = community, public projects, institutions  
+Scaena Occulta = underground, pseudonymous, experimental spaces
+
+Every entry in your master CV belongs to one actor (you), but can be tagged with one or more personae, one aetas, and one or more scaenae.
+
+2.  How to encode an entry: one source, many views
+
+In your curriculum\_vitae\_multiplex file, describe each role once, then give it metadata.
+
+Example entry in plain text:
+
+Title: Visiting Lecturer in Hybrid Narrative Systems  
+Place: Department of X, University Y  
+Years: 2021–2023  
+Description: Designed and taught experimental courses connecting mythic structures, interactive fiction, and code-driven narrative engines. Supervised student projects in multimodal storytelling and computational poetics.
+
+Then attach a compact metadata line:
+
+Tags: personae=\[Persona Sapiens, Persona Fabulator\]; aetas=Aetas Media; scaenae=\[Scaena Academica, Scaena Artistica\]
+
+The same event can now be pulled into:  
+a scholar CV (Persona Sapiens, all aetas)  
+an artist CV (Persona Fabulator, all aetas)  
+a technical résumé (because of its “systems” relevance, if you include Persona Mechanica later)  
+a stage-specific dossier for Scaena Academica only (teaching + research)
+
+Keyboard shortcut note: in most editors you can use Command+F / Control+F to jump between “Tags:” lines, and Option+Click / Alt+Click for multi-cursor editing if you want to update mask names everywhere at once.
+
+3.  Different masks across the same stages
+
+Imagine Aetas Multiplex as a crowded act where several masks step forward depending on the stage.
+
+Within Aetas Multiplex you might have:
+
+Persona Sapiens on Scaena Academica  
+Scholarly publications, conference talks, committee work. Tags emphasize research, pedagogy, academic leadership.
+
+Persona Mechanica on Scaena Technica  
+Infrastructure scripts, OS design, GitHub organizations, automation frameworks. Tags emphasize systems, reliability, architecture.
+
+Persona Fabulator on Scaena Artistica  
+Fiction, film, performance, interactive web pieces, myth-splicing projects. Tags emphasize narrative, myth, experimental form.
+
+Persona Errans on Scaena Occulta  
+Pseudonymous work, boundary-pushing experiments, things that stay off the main, “official” record but still belong to the life-course.
+
+Practically, when you generate a mask-specific résumé you filter first by persona, then optionally by aetas and scaena. For example: Persona Mechanica plus Aetas Multiplex plus Scaena Technica gives a clean, tech-facing résumé that still comes from the same source file.
+
+4.  Same mask across different stages
+
+Now flip it: track how one persona evolves through the life-course. Take Persona Fabulator.
+
+Aetas Primaria + Scaena Artistica  
+Early publications, student films, chapbooks, zines, tiny readings or screenings. Emphasis: raw experimentation and first attempts.
+
+Aetas Media + Scaena Academica and Scaena Artistica  
+Projects where narrative and theory cross: a thesis, a scholarly article about myth, a performance-lecture. Emphasis: building authority and vocabulary.
+
+Aetas Multiplex + Scaena Technica and Scaena Artistica  
+Operating-system-like projects, generative engines, multimodal myth architectures. Emphasis: narrative as system, story as interface.
+
+Aetas Transitus (whenever it occurs)  
+Major pivot: perhaps a large-scale work, a book, or a shift in medium. Emphasis: the moment this mask “sheds its skin” and becomes something else.
+
+In a dossier for Persona Fabulator you can choose to show the full arc (all aetas), or focus on a single stage if you want a sharply framed snapshot.
+
+5.  Making the “different stages” visible in the documents
+
+In the master CV, use subheadings grouped by aetas so the temporal stage is always visible:
+
+Aetas Primaria – Initiationis  
+Then list entries tagged with that aetas.
+
+Aetas Media – Consolidationis  
+Then its entries, and so on.
+
+Within each temporal stage, you can sort entries by scaenae and personae in prose. For example:
+
+Under Aetas Multiplex you might write:
+
+On Scaena Academica, Persona Sapiens consolidated a teaching and research profile in hybrid narrative systems, evidenced by \[…\].  
+On Scaena Technica, Persona Mechanica architected and maintained the creative-technical infrastructure, including \[…\].  
+On Scaena Artistica, Persona Fabulator developed and presented works that translated these structures into affective, public-facing forms, such as \[…\].
+
+You never break the Latin-theatre conceit: reader is always reminded that these are masks walking on and off different stages in different acts.
+
+6.  Minimal implementation layer
+
+If you want a concrete switchboard for your filters, you can define a few environment variables to drive scripts or just to keep things mentally organized:
+
+export MASK\_CURRENT="Persona\_Fabulator"  
+export AETAS\_FILTER="Aetas\_Multiplex"  
+export SCAENAE\_FILTER="Scaena\_Artistica,Scaena\_Technica"
+
+Conceptually, changing MASK\_CURRENT is “changing masks,” changing AETAS\_FILTER is “jumping to a different act in the play,” and changing SCAENAE\_FILTER is “stepping from one stage to another.”
+
+In an editor, you can quickly clone and tweak a resumé variant by selecting all occurrences of MASK\_CURRENT (Command+D / Control+D repeatedly to multi-select) and swapping the persona or stage labels.
+
+If you would like, I can now write one fully worked example: a single role or project written once in the master CV style, then shown as it would appear in three different mask-and-stage configurations.
+
+
+
+---
+Powered by [ChatGPT Exporter](https://www.chatgptexporter.com)

--- a/docs/archived/foundations/FOUND-004-identity-narrative-questions.md
+++ b/docs/archived/foundations/FOUND-004-identity-narrative-questions.md
@@ -1,0 +1,31 @@
+> **⚠️ ARCHIVED — HISTORICAL SNAPSHOT**
+> This document reflects the state at time of writing and may not match current implementation.
+> For current status, see [`docs/FEATURE-AUDIT.md`](../../FEATURE-AUDIT.md).
+
+# Identity and narrative questions
+
+> **Historical Document** — This is an archived foundational design document. The implementation has evolved since this was written. See `docs/README.md` for current documentation and `docs/FEATURE-AUDIT.md` for current feature status.
+
+**User:** [redacted]  
+**Created:** 11/25/2025 15:32:15  
+**Updated:** 11/25/2025 15:32:18  
+**Exported:** 12/26/2025 13:35:03  
+**Link:** [redacted — personal conversation link]  
+
+## Prompt:
+1. What is the core identity or thesis that must remain invariant across all outputs?
+2. Which claims or attributes require external verification, evidence, or triangulation?
+3. What temporal arcs (periods, phases, epochs) define the evolution of this identity?
+4. Which contradictions or tensions exist within the narrative, and how should they be treated?
+5. What non-obvious influences or intellectual lineages should be included in the narrative structure?
+6. What strategic differentiators are often overlooked in similar profiles or narratives?
+7. Which parts of the identity need to be modular, mask-based, or contextually activated?
+8. What would an adversarial or skeptical evaluator challenge, and what evidence would counter them?
+
+## Response:
+To tailor responses effectively, could you clarify the context for these questions? Are you referring to an individual's personal/professional biography (such as your interactive CV), a brand identity, a character design, or something else? Also, is this for self-presentation, storytelling, academic framing, or strategic positioning?
+
+
+
+---
+Powered by [ChatGPT Exporter](https://www.chatgptexporter.com)

--- a/docs/archived/foundations/FOUND-005-prospecting-research-prompts.md
+++ b/docs/archived/foundations/FOUND-005-prospecting-research-prompts.md
@@ -1,0 +1,228 @@
+> **⚠️ ARCHIVED — HISTORICAL SNAPSHOT**
+> This document reflects the state at time of writing and may not match current implementation.
+> For current status, see [`docs/FEATURE-AUDIT.md`](../../FEATURE-AUDIT.md).
+
+# Prospecting questions development
+
+> **Historical Document** — This is an archived foundational design document. The implementation has evolved since this was written. See `docs/README.md` for current documentation and `docs/FEATURE-AUDIT.md` for current feature status.
+
+**User:** [redacted]  
+**Created:** 11/25/2025 15:27:34  
+**Updated:** 11/25/2025 15:50:43  
+**Exported:** 12/26/2025 13:35:19  
+**Link:** [redacted — personal conversation link]  
+
+## Prompt:
+Develop prospecting/qualifying questions for prompting deep research for current project; give each domain a separate code window w. Full prompt ai handoff;
+
+3/3
+
+## Response:
+Below is a structured set of **prospecting / qualifying question packs** engineered specifically for **deep-research prompting** in your current project (interactive CV/résumé system, identity masks, narrative arcs, schema/architecture, product roadmap, etc.).  
+Each domain is delivered in a **separate code window** containing a **full prompt handoff** ready to be used verbatim in any AI workflow.
+
+If you want, I can also generate a _meta-orchestrator prompt_ that dynamically selects across these modules.
+
+* * *
+
+1\. Identity, Narrative, and Masks
+----------------------------------
+
+```
+You are an analytical researcher tasked with extracting the underlying identity architecture, narrative invariants, and persona masks for a multi-layered interactive CV/résumé system.
+
+Research Task:
+- Map the fundamental identity thesis that must remain stable across all masks, epochs, or narrative expressions.
+- Identify claims requiring external verification (credentials, dates, collaborations, institutions).
+- Analyze temporal arcs and creative phases: their triggers, outputs, transitions, and discontinuities.
+- Surface tensions or contradictions within the identity and classify them as productive, structural, or removable.
+- Identify hidden or non-obvious intellectual lineages (movements, theorists, artistic traditions, technical schools).
+- Document strategic differentiators that competitors rarely emphasize but this profile can uniquely own.
+- Determine which identity components must be modular, mask-based, or contextually activated.
+- Identify attack vectors from skeptical evaluators and specify evidence that neutralizes each.
+
+Output Requirements:
+- Identity thesis summary.
+- Mask taxonomy with purpose, activation context, constraints, and affordances.
+- Narrative evolution map (phases, boundaries, catalysts).
+- Verification checklist for external fact-tracing.
+- Tension matrix with recommended treatments.
+- Intellectual lineage diagram (text-based).
+- Differentiator inventory.
+- Skeptic-proofing dossier.
+
+Ask clarifying questions **only if required** for precision.
+```
+
+* * *
+
+2\. Product Strategy, Roadmapping, and Scoping
+----------------------------------------------
+
+```
+You are conducting strategic discovery to define the product boundaries, constraints, and resource topology for an interactive CV/résumé platform. Time is represented as units of energy/effort rather than calendar dates.
+
+Research Task:
+- Identify core value propositions and “jobs to be done” for the platform.
+- Determine minimum viable features, expandable modules, and future-phase capabilities.
+- Map stakeholder segments (user, reviewer, institution, collaborator).
+- Surface risk factors and dependencies (technical, regulatory, narrative).
+- Define energy-based time horizons (E1 immediate, E2 mid-range, E3 long-range).
+- Identify resource classes needed (technical, narrative, editorial, design, compliance).
+- Conduct competitive landscape analysis, including analogous systems (blockchain CV, DID, VC, traditional résumé tools).
+- Detect leverage points where small energy investments create outsized returns.
+
+Output Requirements:
+- Product concept map.
+- Feature-stack decomposition.
+- Stakeholder matrix.
+- Risk registers and mitigation paths.
+- Effort-based timeline (E1/E2/E3).
+- Resource plan.
+- Competitive differentiation narrative.
+
+Ask clarifying questions only if needed.
+```
+
+* * *
+
+3\. Technical Architecture, Infrastructure, Data Models
+-------------------------------------------------------
+
+```
+You are auditing and designing the technical architecture for a modular, mask-enabled, interactive résumé system that may include DID, verifiable credentials, schema registries, and interactive media rendering.
+
+Research Task:
+- Determine all architectural components required (frontend, backend, identity, storage, provenance, rendering, versioning).
+- Identify interfaces between modules (APIs, contracts, schemas).
+- Propose data models and entity relationships for identity layers, masks, narratives, credentials, and interaction logs.
+- Evaluate on-chain/off-chain splits for trust, speed, and storage.
+- Identify standards (DID, VC, schema.org, custom schemas) that should be adopted or extended.
+- Assess security, privacy, and consent models.
+- Determine scalability mechanisms and future-proofing strategies.
+
+Output Requirements:
+- Architecture diagram (textual or ASCII if needed).
+- Component descriptions.
+- Interface definitions.
+- Data-schema specification.
+- Security and trust model.
+- Future-architecture migration paths.
+
+Ask clarifying questions only if necessary.
+```
+
+* * *
+
+4\. Schema Specification, Ontologies, and Data Governance
+---------------------------------------------------------
+
+```
+You are designing a schema and ontology for representing identity, narrative phases, masks, credentials, and temporal arcs in a structured and machine-interpretable form.
+
+Research Task:
+- Identify all required entities, attributes, relationships, and constraints.
+- Define canonical forms for identity invariants, modular masks, timelines, credentials, and narrative states.
+- Map validation logic and required external references.
+- Define versioning behavior for the schema.
+- Evaluate alignment with existing standards (schema.org/Person, EIP-712, W3C VCs, JSON-LD).
+- Document required governance rules for updates, extensions, and deprecations.
+
+Output Requirements:
+- Full schema with entities, fields, types, constraints.
+- Narrative and identity ontology map.
+- Versioning policy.
+- Validation rules.
+- Governance model.
+
+Ask clarifying questions only if needed.
+```
+
+* * *
+
+5\. Concept Deck / Positioning Framework
+----------------------------------------
+
+```
+You are developing a concept deck that positions the interactive CV/résumé system as a category-defining artifact.
+
+Research Task:
+- Define the central concept in precise, differentiated language.
+- Map audience segments and their differing expectations.
+- Identify metaphors that elegantly explain the system (e.g., blockchain as résumé analogue).
+- Generate narrative scaffolds: problem framing, solution overview, architecture summary, value narrative.
+- Derive 3–5 conceptual frames (e.g., ontological, functional, artistic, computational).
+- Identify how masks, temporal arcs, and identity invariants integrate into the deck.
+
+Output Requirements:
+- One-page concept definition.
+- Multi-frame positioning matrix.
+- Audience segmentation and message tailoring.
+- Core narrative modules for slide deck.
+- Visual metaphors and structural language.
+
+Ask clarifying questions only if required.
+```
+
+* * *
+
+6\. Persona Masks, Stages, Epochs, and Settings
+-----------------------------------------------
+
+```
+You are mapping ontological-functional, non-branded persona masks; their roles; their activation contexts; and their representation across stages, epochs, and narrative settings.
+
+Research Task:
+- Identify the full taxonomy of masks and their operational functions.
+- Define dimensions: cognitive stance, communicative stance, temporal alignment, narrative purpose.
+- Map transitions among masks and across epochs.
+- Determine how each mask reframes the identity while preserving invariants.
+- Identify stage/epoch boundaries, conditions for entering/exiting, and markers of evolution.
+- Document emergent tensions or contradictions each mask helps resolve.
+
+Output Requirements:
+- Mask taxonomy table.
+- Activation/transition matrix.
+- Epoch map.
+- Setting descriptors.
+- Identity invariance rules per mask.
+
+Ask clarifying questions only if needed.
+```
+
+* * *
+
+7\. Research-Oriented Prospector for Deep Background / Lineage
+--------------------------------------------------------------
+
+```
+You are conducting lineage and influence excavation for a creative–technical professional across art, academia, and programming.
+
+Research Task:
+- Identify intellectual traditions, movements, schools, and thinkers relevant to the profile.
+- Classify direct vs. indirect influences.
+- Map cross-disciplinary bridges (art–code, theory–practice, identity–system design).
+- Identify gaps or underexplored areas requiring deeper research.
+- Provide curated source directions for deeper inquiry.
+
+Output Requirements:
+- Influence map.
+- Primary and secondary lineage strands.
+- Cross-disciplinary matrix.
+- Recommended research pathways.
+
+Ask clarifying questions only if needed.
+```
+
+* * *
+
+If you'd like, I can now:
+
+1.  Combine all modules into a **single unified “super-prompt”** orchestrator.
+2.  Add **auto-scoring qualifiers** to prioritize research depth.
+3.  Create **API-ready versions** for programmatic use in your system.
+
+
+
+---
+Powered by [ChatGPT Exporter](https://www.chatgptexporter.com)


### PR DESCRIPTION
## Heal — restore mis-classified provenance (PII redacted)

PR #135 removed `docs/archived/foundations/FOUND-00{1..5}-*.md` as "session artifacts." An audit (prompted by the same mis-classification found and reversed in `peer-audited--behavioral-blockchain` #749) shows these are **catalogued provenance** — referenced by `docs/MANIFEST.md`, `docs/README.md`, and `docs/archived/README.md` — so the removal left **dangling references** on `master`.

Unlike the peer-audited case, these files **did** carry personal PII (a `**User:** <name> (<email>)` metadata line and a personal ChatGPT conversation link). So the doctrine-correct fix is neither "leave deleted" (loses catalogued unique work) nor "restore verbatim" (re-leaks PII) — it's **surgical redaction**:

- Restores all five foundational docs (blockchain-as-CV analogy, CV-vs-résumé, meta/Latin etymology, identity-narrative questions, prospecting-research prompts).
- Redacts the `**User:**` name+email and the `**Link:**` personal conversation URL to `[redacted]`.
- Drops the `.gitignore` lines #135 added, so the restored provenance is trackable.

### Verified
- Zero `name` / `email` / personal-link / `/Users/` home-path remains (grep-clean).
- `docs/archived/README.md` references now resolve to existing files.
- Substantive content preserved (46–439 lines/file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
